### PR TITLE
Fileutil package implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ sudo: false
 python:
   - 3.6
 script:
-  - nosetests -v --with-coverage --cover-package=cocoasm
+  - nosetests -v --with-coverage --cover-package=cocoasm --cover-package=fileutil
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/README.md
+++ b/README.md
@@ -12,11 +12,21 @@
 3. [License](#license)
 4. [Installing](#installing)
 5. [Usage](#usage)
+  1. [Input File Format](#input-file-format)
+  2. [Print Symbol Table](#print-symbol-table)
+  3. [Print Assembled Statements](#print-assembled-statements)
+  4. [Save to Binary File](#save-to-binary-file)
+6. [Mnemonic Table](#mnemonic-table)
+  1. [Mnemonics](#mnemonics)
+  2. [Pseudo Operations](#pseudo-operations)
 
 ## What is it?
 
 This project is an assembler for the Tandy Color Computer 1, 2 and 3 written in Python 3.6. 
 It is intended to be statement compatible with any code written for the EDTASM+ assembler.
+The assembler is capable of taking EDTASM+ assembly language code and translating it into
+machine code for the Color Computer 1, 2, and 3. Current support is for 6809 CPU instructions,
+but future enhancements will add 6309 instructions.
 
 ## Requirements
 
@@ -48,12 +58,20 @@ Next, you will need to install the required packages for the file:
 
 To run the assembler:
 
-    python assembler.py input_file --output output_file
+    python assembler.py input_file
 
 This will assemble the instructions found in file `input_file` and will generate
-the associated Color Computer machine instructions in binary format in `output_file`.
+the associated Color Computer machine instructions in binary format. You will need
+to save the assembled contents to a file to be useful. There are several switches
+that are available:
 
-### Input Format
+* `--print` - prints out the assembled statements
+* `--symbols` - prints out the symbol table
+* `--bin_file` - save assembled contents to a binary file
+* `--cas_file` - save assembled contents to a cassette file
+* `--dsk_file` - save assembled contents to a virtual disk file
+
+### Input File Format
 
 The input file needs to follow the format below:
 
@@ -69,7 +87,7 @@ Where:
 An example file:
 
     # A comment line that contains nothing
-
+    
 
 ### Print Symbol Table
 
@@ -83,7 +101,7 @@ Which will have the following output:
     -- Symbol Table --
 
 
-### Print Assembled Statements
+#### Print Assembled Statements
 
 To print out the assembled version of the program, use the `--print` switch:
 
@@ -99,6 +117,18 @@ statement (truncated to 10 hex characters), the third column is the user-supplie
 label for the statement, the forth column is the mnemonic, the fifth
 column is the register values of other numeric or label data the operation will
 work on, and the fifth column is the comment string.
+
+
+### Save to Binary File
+
+To save the assembled contents to a binary file, use the `--bin_file` switch:
+
+    python assembler.py test.asm --bin_file test.bin
+    
+The assembled program will be saved to the file `test.bin`. Note that this file
+may not be useful on its own, as it does not have any meta information about
+where the file should be loaded in memory. If the file `test.bin` exists, it will
+be erased and overwritten.
 
 ## Mnemonic Table
 

--- a/assembler.py
+++ b/assembler.py
@@ -9,6 +9,7 @@ A Color Computer Assembler - see the README.md file for details.
 import argparse
 
 from cocoasm.program import Program
+from fileutil.virtualfiles import BinaryFile
 
 # F U N C T I O N S ###########################################################
 
@@ -30,7 +31,7 @@ def parse_arguments():
         help="print out the assembled statements when finished"
     )
     parser.add_argument(
-        "--output", metavar="FILE", help="stores the assembled program in FILE")
+        "--bin_file", metavar="FILE", help="stores the assembled program in a binary FILE")
     return parser.parse_args()
 
 
@@ -48,10 +49,16 @@ def main(args):
     if args.print:
         program.print_statements()
 
-    if args.output:
-        program.save_binary_file(args.output)
+    if args.bin_file:
+        binary_file = BinaryFile()
+        binary_file.open_host_file(args.bin_file)
+        binary_file.save_file(None, program.get_binary_array())
+        binary_file.close_host_file()
+
+# M A I N #####################################################################
 
 
-main(parse_arguments())
+if __name__ == '__main__':
+    main(parse_arguments())
 
 # E N D   O F   F I L E #######################################################

--- a/assembler.py
+++ b/assembler.py
@@ -22,7 +22,9 @@ def parse_arguments():
         description="Assembler for the Tandy Color Computer 1, 2, and 3. See README.md for more "
         "information, and LICENSE for terms of use."
     )
-    parser.add_argument("filename", help="the input file")
+    parser.add_argument(
+        "filename", help="the assembly language input file"
+    )
     parser.add_argument(
         "--symbols", action="store_true", help="print out the symbol table"
     )
@@ -31,7 +33,14 @@ def parse_arguments():
         help="print out the assembled statements when finished"
     )
     parser.add_argument(
-        "--bin_file", metavar="FILE", help="stores the assembled program in a binary FILE")
+        "--bin_file", metavar="BIN_FILE", help="stores the assembled program in a binary BIN_FILE"
+    )
+    parser.add_argument(
+        "--cas_file", metavar="CAS_FILE", help="stores the assembled program in a cassette image CAS_FILE"
+    )
+    parser.add_argument(
+        "--dsk_file", metavar="DSK_FILE", help="stores the assembled program in a disk image DSK_FILE"
+    )
     return parser.parse_args()
 
 

--- a/cocoasm/program.py
+++ b/cocoasm/program.py
@@ -131,12 +131,12 @@ class Program(object):
             if value.is_type(ValueType.ADDRESS):
                 self.symbol_table[symbol] = self.statements[value.int].code_pkg.address
 
-    def save_binary_file(self, filename):
+    def get_binary_array(self):
         """
-        Writes out the assembled statements to the specified file
-        name.
+        Returns an array containing the machine code statements for the
+        assembled program.
 
-        :param filename: the name of the file to save statements
+        :return: returns the assembled program bytes
         """
         machine_codes = []
         for statement in self.statements:
@@ -153,8 +153,7 @@ class Program(object):
                     additional = statement.code_pkg.additional.hex()
                     hex_byte = "{}{}".format(additional[index], additional[index + 1])
                     machine_codes.append(int(hex_byte, 16))
-        with open(filename, "wb") as outfile:
-            outfile.write(bytearray(machine_codes))
+        return machine_codes
 
     def print_symbol_table(self):
         """

--- a/fileutil/virtualfiles.py
+++ b/fileutil/virtualfiles.py
@@ -17,7 +17,31 @@ class CoCoFile(object):
 
 class VirtualFile(ABC):
     def __init__(self):
-        pass
+        self.host_file = None
+
+    def open_host_file(self, filename):
+        """
+        Opens the file on the host drive for reading.
+
+        :param filename: the name of the file to open
+        """
+        self.host_file = open(filename, "wb")
+
+    def close_host_file(self):
+        """
+        Closes the file on the host drive.
+        """
+        if self.host_file:
+            self.host_file.close()
+            self.host_file = None
+
+    def is_host_file_open(self):
+        """
+        Returns True if a host file is open, False otherwise.
+
+        :return: True if the host file is open, False otherwise
+        """
+        return self.host_file is not None
 
     @abstractmethod
     def list_files(self):
@@ -28,26 +52,12 @@ class VirtualFile(ABC):
         """
 
     @abstractmethod
-    def open_host_file(self, filename):
-        """
-        Opens the file on the host drive for reading.
-
-        :param filename: the name of the file to open
-        """
-
-    @abstractmethod
     def save_file(self, name, raw_bytes):
         """
         Saves the specified file to the virtual image.
 
         :param name: the name of the program
         :param raw_bytes: the raw bytes of the file
-        """
-
-    @abstractmethod
-    def close_host_file(self):
-        """
-        Closes the file on the host drive.
         """
 
 
@@ -65,15 +75,8 @@ class BinaryFile(VirtualFile):
     def list_files(self):
         return []
 
-    def open_host_file(self, filename):
-        self.outfile = open(filename, "wb")
-
     def save_file(self, name, raw_bytes):
-        self.outfile.write(bytearray(raw_bytes))
-
-    def close_host_file(self):
-        if self.outfile:
-            self.outfile.close()
+        self.host_file.write(bytearray(raw_bytes))
 
 
 class CassetteFile(VirtualFile):
@@ -83,13 +86,7 @@ class CassetteFile(VirtualFile):
     def list_files(self):
         pass
 
-    def open_host_file(self, filename):
-        pass
-
     def save_file(self, name, raw_bytes):
-        pass
-
-    def close_host_file(self):
         pass
 
 
@@ -100,13 +97,7 @@ class DiskFile(VirtualFile):
     def list_files(self):
         pass
 
-    def open_host_file(self, filename):
-        pass
-
     def save_file(self, name, raw_bytes):
-        pass
-
-    def close_host_file(self):
         pass
 
 # E N D   O F   F I L E #######################################################

--- a/fileutil/virtualfiles.py
+++ b/fileutil/virtualfiles.py
@@ -1,0 +1,112 @@
+"""
+Copyright (C) 2019-2020 Craig Thomas
+
+This project uses an MIT style license - see LICENSE for details.
+A Color Computer Assembler - see the README.md file for details.
+"""
+# I M P O R T S ###############################################################
+
+from abc import ABC, abstractmethod
+
+# C L A S S E S ###############################################################
+
+
+class CoCoFile(object):
+    pass
+
+
+class VirtualFile(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def list_files(self):
+        """
+        Lists the files contained within the virtual file.
+
+        :return: a list of CoCoFile objects in the virtual file
+        """
+
+    @abstractmethod
+    def open_host_file(self, filename):
+        """
+        Opens the file on the host drive for reading.
+
+        :param filename: the name of the file to open
+        """
+
+    @abstractmethod
+    def save_file(self, name, raw_bytes):
+        """
+        Saves the specified file to the virtual image.
+
+        :param name: the name of the program
+        :param raw_bytes: the raw bytes of the file
+        """
+
+    @abstractmethod
+    def close_host_file(self):
+        """
+        Closes the file on the host drive.
+        """
+
+
+class BinaryFile(VirtualFile):
+    """
+    A binary file is a single file on the host filesystem that contains the
+    assembled program code. Note that no meta-information about the binary
+    file is stored within the file. Binary files store exactly one machine
+    code program, therefore list_files returns an empty list.
+    """
+    def __init__(self):
+        super().__init__()
+        self.outfile = None
+
+    def list_files(self):
+        return []
+
+    def open_host_file(self, filename):
+        self.outfile = open(filename, "wb")
+
+    def save_file(self, name, raw_bytes):
+        self.outfile.write(bytearray(raw_bytes))
+
+    def close_host_file(self):
+        if self.outfile:
+            self.outfile.close()
+
+
+class CassetteFile(VirtualFile):
+    def __init__(self):
+        super().__init__()
+
+    def list_files(self):
+        pass
+
+    def open_host_file(self, filename):
+        pass
+
+    def save_file(self, name, raw_bytes):
+        pass
+
+    def close_host_file(self):
+        pass
+
+
+class DiskFile(VirtualFile):
+    def __init__(self):
+        super().__init__()
+
+    def list_files(self):
+        pass
+
+    def open_host_file(self, filename):
+        pass
+
+    def save_file(self, name, raw_bytes):
+        pass
+
+    def close_host_file(self):
+        pass
+
+# E N D   O F   F I L E #######################################################

--- a/test/test_virtualfiles.py
+++ b/test/test_virtualfiles.py
@@ -1,0 +1,36 @@
+"""
+Copyright (C) 2019-2020 Craig Thomas
+
+This project uses an MIT style license - see LICENSE for details.
+A Color Computer Assembler - see the README.md file for details.
+"""
+# I M P O R T S ###############################################################
+
+import unittest
+
+from fileutil.virtualfiles import BinaryFile
+
+# C L A S S E S ###############################################################
+
+
+class TestBinaryFile(unittest.TestCase):
+    """
+    A test class for the BinaryFile class.
+    """
+    def setUp(self):
+        """
+        Common setup routines needed for all unit tests.
+        """
+
+    def test_list_files_returns_empty_list(self):
+        binary_file = BinaryFile()
+        result = binary_file.list_files()
+        self.assertEqual([], result)
+
+
+# M A I N #####################################################################
+
+if __name__ == '__main__':
+    unittest.main()
+
+# E N D   O F   F I L E #######################################################


### PR DESCRIPTION
This PR implements a new `fileutil` package that contains code for saving and reading various virtual media file formats (cassette files, disk images, etc). A single basic class for dumping an assembled program to a binary file is implemented. Stubs are created for additional classes. This PR closes issue #8 