### PR TITLE
NAM pseudo operation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,16 @@ it will be erased and overwritten.
 
 ### Save to Cassette File
 
-To save the assembled contents to a cassette file, use the `--cas_file` switch, 
-along with the `--name` switch:
+To save the assembled contents to a cassette file, use the `--cas_file` switch:
 
-    python assembler.py test.asm --cas_file test.cas --name myprog
+    python assembler.py test.asm --cas_file test.cas
     
 This will assemble the program and save it to a cassette file called `test.cas`.
-In turn, the program name on the cassette file will be `myprog`. _NOTE_: if the
-file `test.cas` exists, it will be erased and overwritten.
+The source code must include the `NAM` mnemonic to name the program (e.g. 
+`NAM myprog`), or the `--name` switch must be used on the command line (e.g.
+`--name myprog`). The program name on the cassette file will be `myprog`. 
+
+**NOTE**: if the file `test.cas` exists, it will be erased and overwritten.
 
     
 ## Mnemonic Table
@@ -192,6 +194,7 @@ symbols are:
 | `END`    | Defines the end of the program.                                            | `END`                  |
 | `EQU`    | Defines a symbol with a set value.                                         | `SCRMEM EQU $1000`     |
 | `INCLUDE`| Includes another assembly source file at this location.                    | `INCLUDE globals.asm`  |
+| `NAM`    | Sets the name for the program when assembled to disk or cassette.          | `NAM myprog`           |
 | `ORG`    | Defines where in memory the program should originate at.                   | `ORG $0E00`            |
 | `SETDP`  | Sets the direct page value for the assembler (see notes below).            | `SETDP $0E00`          |
 

--- a/assembler.py
+++ b/assembler.py
@@ -53,7 +53,9 @@ def main(args):
 
     :param args: the command-line arguments
     """
-    program = Program(args.filename)
+    program = Program()
+    program.process(args.filename)
+    name = program.name or args.name
 
     if args.symbols:
         program.print_symbol_table()
@@ -68,12 +70,12 @@ def main(args):
         binary_file.close_host_file()
 
     if args.cas_file:
-        if not args.name:
-            print("No --name for the program specified, not creating cassette file")
+        if not name:
+            print("No name for the program specified, not creating cassette file")
             return
         binary_file = CassetteFile(program.origin, program.origin)
         binary_file.open_host_file(args.cas_file)
-        binary_file.save_file(args.name, program.get_binary_array())
+        binary_file.save_file(name, program.get_binary_array())
         binary_file.close_host_file()
 
 # M A I N #####################################################################

--- a/cocoasm/instruction.py
+++ b/cocoasm/instruction.py
@@ -123,6 +123,7 @@ class Instruction(NamedTuple):
     is_short_branch: bool = False
     is_long_branch: bool = False
     is_origin: bool = False
+    is_name: bool = False
     func: Callable[..., str] = None
 
     def translate_pseudo(self, operand):
@@ -148,6 +149,9 @@ class Instruction(NamedTuple):
             return CodePackage(additional=operand.value, size=operand.value.byte_len())
 
         if self.mnemonic == "END":
+            return CodePackage()
+
+        if self.mnemonic == "NAM":
             return CodePackage()
 
     def translate_special(self, operand, statement):
@@ -392,7 +396,8 @@ INSTRUCTIONS = [
     Instruction(mnemonic="FDB", is_pseudo=True),
     Instruction(mnemonic="FCC", is_pseudo=True, is_string_define=True),
     Instruction(mnemonic="SETDP", is_pseudo=True),
-    Instruction(mnemonic="INCLUDE", is_pseudo=True, is_include=True)
+    Instruction(mnemonic="INCLUDE", is_pseudo=True, is_include=True),
+    Instruction(mnemonic="NAM", is_pseudo=True, is_name=True)
 ]
 
 # E N D   O F   F I L E #######################################################

--- a/cocoasm/program.py
+++ b/cocoasm/program.py
@@ -21,12 +21,12 @@ class Program(object):
     contains a list of statements. Additionally, a Program keeps track of all
     the user-defined symbols in the program.
     """
-    def __init__(self, filename):
+    def __init__(self):
         self.symbol_table = dict()
         self.statements = []
         self.address = 0x0
         self.origin = NoneValue()
-        self.process(filename)
+        self.name = None
 
     def process(self, filename):
         """
@@ -132,10 +132,12 @@ class Program(object):
             if value.is_type(ValueType.ADDRESS):
                 self.symbol_table[symbol] = self.statements[value.int].code_pkg.address
 
-        # Find the origin of the project
+        # Find the origin and name of the project
         for statement in self.statements:
             if statement.instruction.is_origin:
                 self.origin = statement.code_pkg.address
+            if statement.instruction.is_name:
+                self.name = statement.operand.operand_string
 
     def get_binary_array(self):
         """

--- a/test/test_program.py
+++ b/test/test_program.py
@@ -1,0 +1,52 @@
+"""
+Copyright (C) 2019-2020 Craig Thomas
+
+This project uses an MIT style license - see LICENSE for details.
+This file contains the main Program class for the CoCo Assembler.
+"""
+# I M P O R T S ###############################################################
+
+import unittest
+
+from cocoasm.program import Program
+from cocoasm.statement import Statement
+
+# C L A S S E S ###############################################################
+
+
+class TestProgram(unittest.TestCase):
+    """
+    A test class for the Program class.
+    """
+    def setUp(self):
+        """
+        Common setup routines needed for all unit tests.
+        """
+
+    def test_nam_mnemonic_sets_name(self):
+        statement = Statement("    NAM test")
+        program = Program()
+        program.statements = [statement]
+        program.translate_statements()
+        self.assertEqual("test", program.name)
+
+    def test_nam_mnemonic_empty(self):
+        program = Program()
+        program.statements = []
+        program.translate_statements()
+        self.assertEqual(None, program.name)
+
+    def test_org_sets_origin(self):
+        statement = Statement("    ORG $1234")
+        program = Program()
+        program.statements = [statement]
+        program.translate_statements()
+        self.assertEqual("1234", program.origin.hex())
+
+
+# M A I N #####################################################################
+
+if __name__ == '__main__':
+    unittest.main()
+
+# E N D   O F   F I L E #######################################################


### PR DESCRIPTION
This PR adds the pseudo operation `NAM` to the assembler. Setting the `NAM` within the source file listing will set the name of the assembled program when saved to disk or cassette. If the `NAM` is not specified, then the `--name` switch on the command line will take precedence. If neither are specified, then the assembly will fail when writing to disk or cassette. Unit tests updated to cover new functionality. README updated to contain pseudo operation description. This PR closes #16 