### PR TITLE
Operands test coverage

### DIFF
--- a/cocoasm/operands.py
+++ b/cocoasm/operands.py
@@ -151,6 +151,14 @@ class Operand(ABC):
         return self.type == operand_type
 
     def resolve_symbols(self, symbol_table):
+        """
+        Given a symbol table, searches the operands for any symbols, and resolves
+        them with values from the symbol table. Returns a (possibly) new Operand
+        class type as a result of symbol resolution.
+
+        :param symbol_table: the symbol table to search
+        :return: self, or a new Operand class type with a resolved value
+        """
         if self.is_type(OperandType.EXPRESSION):
             return self.resolve_expression(symbol_table)
 
@@ -172,6 +180,14 @@ class Operand(ABC):
             return ExtendedOperand(self.operand_string, self.instruction, value=self.value)
 
     def resolve_expression(self, symbol_table):
+        """
+        Attempts to resolve the expression contained in the operand using the
+        symbol table supplied. Returns a (possibly) new Operand class type as a
+        result of symbol resolution.
+
+        :param symbol_table: the symbol table to use for resolution
+        :return: self, or a new Operand class type with a resolved value
+        """
         if self.left.is_type(ValueType.SYMBOL):
             self.left = self.get_symbol(self.left.ascii(), symbol_table)
 

--- a/cocoasm/operands.py
+++ b/cocoasm/operands.py
@@ -39,7 +39,7 @@ EXTENDED_INDIRECT_REGEX = re.compile(
 
 # Patten to recognize an expression
 EXPRESSION_REGEX = re.compile(
-    r"^(?P<left>[\d\w]+)(?P<operation>[+\-/*])(?P<right>[\d\w]+)$"
+    r"^(?P<left>[$]*[\d\w]+)(?P<operation>[+\-/*])(?P<right>[$]*[\d\w]+)$"
 )
 
 # Pattern to recognize invalid characters in an UnknownOperand
@@ -296,13 +296,13 @@ class SpecialOperand(Operand):
         if self.instruction.mnemonic == "EXG" or self.instruction.mnemonic == "TFR":
             registers = self.operand_string.split(",")
             if len(registers) != 2:
-                raise ValueError("{} requires exactly 2 registers".format(self.instruction.mnemonic))
+                raise ValueError("[{}] requires exactly 2 registers".format(self.instruction.mnemonic))
 
             if registers[0] not in REGISTERS:
-                raise ValueError("unknown register {}".format(registers[0]))
+                raise ValueError("[{}] unknown register".format(registers[0]))
 
             if registers[1] not in REGISTERS:
-                raise ValueError("unknown register {}".format(registers[1]))
+                raise ValueError("[{}] unknown register".format(registers[1]))
 
             code_pkg.post_byte |= 0x00 if registers[0] == "D" else 0x00
             code_pkg.post_byte |= 0x00 if registers[1] == "D" else 0x00
@@ -345,7 +345,7 @@ class SpecialOperand(Operand):
                         0x88, 0x99, 0xAA, 0xBB
                     ]:
                 raise ValueError(
-                    "{} of {} to {} not allowed".format(self.instruction.mnemonic, registers[0], registers[1]))
+                    "[{}] of [{}] to [{}] not allowed".format(self.instruction.mnemonic, registers[0], registers[1]))
 
         code_pkg.post_byte = NumericValue(code_pkg.post_byte)
         return code_pkg

--- a/cocoasm/operands.py
+++ b/cocoasm/operands.py
@@ -29,7 +29,7 @@ DIRECT_REGEX = re.compile(
 
 # Pattern to recognize an extended value
 EXTENDED_REGEX = re.compile(
-    r"^<(?P<value>.*)"
+    r"^>(?P<value>.*)"
 )
 
 # Pattern to recognize an indexed value
@@ -186,9 +186,9 @@ class Operand(ABC):
             if self.operation == "-":
                 self.value = NumericValue("{}".format(left - right))
             if self.operation == "*":
-                self.value = NumericValue("{}".format(left * right))
+                self.value = NumericValue("{}".format(int(left * right)))
             if self.operation == "/":
-                self.value = NumericValue("{}".format(left / right))
+                self.value = NumericValue("{}".format(int(left / right)))
             if self.value.hex_len() == 2:
                 return DirectOperand(self.operand_string, self.instruction, value=self.value)
             return ExtendedOperand(self.operand_string, self.instruction, value=self.value)
@@ -424,7 +424,7 @@ class DirectOperand(Operand):
             return
         match = DIRECT_REGEX.match(self.operand_string)
         if match:
-            self.value = Value.create_from_str(match.group("value")[1:], instruction)
+            self.value = Value.create_from_str(match.group("value"), instruction)
         else:
             self.value = Value.create_from_str(operand_string, instruction)
         if self.value is None or self.value.byte_len() != 1:
@@ -448,7 +448,7 @@ class ExtendedOperand(Operand):
             return
         match = EXTENDED_REGEX.match(self.operand_string)
         if match:
-            self.value = Value.create_from_str(match.group("value")[1:], instruction)
+            self.value = Value.create_from_str(match.group("value"), instruction)
         else:
             self.value = Value.create_from_str(operand_string, instruction)
         if self.value is None or self.value.byte_len() != 2:

--- a/cocoasm/operands.py
+++ b/cocoasm/operands.py
@@ -451,6 +451,7 @@ class ExtendedOperand(Operand):
             self.value = Value.create_from_str(match.group("value"), instruction)
         else:
             self.value = Value.create_from_str(operand_string, instruction)
+
         if self.value is None or self.value.byte_len() != 2:
             raise ValueError("[{}] is not an extended value".format(operand_string))
 

--- a/test/test_operands.py
+++ b/test/test_operands.py
@@ -281,7 +281,7 @@ class TestExpressionOperand(unittest.TestCase):
             "BLAH2": NumericValue(1)
         }
         operand = ExpressionOperand("BLAH1+BLAH2", self.instruction)
-        operand = operand.resolve_expression(symbol_table=symbol_table)
+        operand = operand.resolve_symbols(symbol_table=symbol_table)
         self.assertEqual("03", operand.value.hex())
 
 

--- a/test/test_operands.py
+++ b/test/test_operands.py
@@ -275,6 +275,15 @@ class TestExpressionOperand(unittest.TestCase):
             operand.resolve_expression({})
         self.assertEqual("[$02+$02] unresolved expression", str(context.exception))
 
+    def test_expression_resolve_symbols_resolves_expression(self):
+        symbol_table = {
+            "BLAH1": NumericValue(2),
+            "BLAH2": NumericValue(1)
+        }
+        operand = ExpressionOperand("BLAH1+BLAH2", self.instruction)
+        operand = operand.resolve_expression(symbol_table=symbol_table)
+        self.assertEqual("03", operand.value.hex())
+
 
 class TestPseudoOperand(unittest.TestCase):
     """


### PR DESCRIPTION
This PR completely covers the `opreands.py` file and the various operands classes within it. Several fixes were made to the various operand classes. Coverage now exists at 100%. This PR covers issue #4