### PR TITLE
Implement the RMB pseudo operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ symbols are:
 | `INCLUDE`| Includes another assembly source file at this location.                    | `INCLUDE globals.asm`  |
 | `NAM`    | Sets the name for the program when assembled to disk or cassette.          | `NAM myprog`           |
 | `ORG`    | Defines where in memory the program should originate at.                   | `ORG $0E00`            |
+| `RMB`    | Defines a block of _n_ bytes initialized to a zero value.                  | `RMB $8`               |
 | `SETDP`  | Sets the direct page value for the assembler (see notes below).            | `SETDP $0E00`          |
 
 **Notes**

--- a/cocoasm/operands.py
+++ b/cocoasm/operands.py
@@ -264,6 +264,9 @@ class PseudoOperand(Operand):
         if self.instruction.mnemonic == "FDB":
             return CodePackage(additional=NumericValue(self.value.int, size_hint=4), size=2)
 
+        if self.instruction.mnemonic == "RMB":
+            return CodePackage(additional=NumericValue(0, size_hint=self.value.int*2), size=self.value.int)
+
         if self.instruction.mnemonic == "ORG":
             return CodePackage(address=self.value)
 

--- a/cocoasm/statement.py
+++ b/cocoasm/statement.py
@@ -160,7 +160,7 @@ class Statement(object):
         of a branch, jump or subroutine call needs to go to, and inserts
         it in the code package for the assembled instruction.
 
-        :param statements: the full set of statements that make up the proram
+        :param statements: the full set of statements that make up the program
         :param this_index: the index that this instruction occurs at
         """
         if self.operand.is_type(OperandType.RELATIVE):

--- a/test/test_operands.py
+++ b/test/test_operands.py
@@ -323,6 +323,12 @@ class TestPseudoOperand(unittest.TestCase):
         code_pkg = operand.translate()
         self.assertEqual("FFCC", code_pkg.additional.hex())
 
+    def test_pseudo_translate_rmb(self):
+        instruction = Instruction(mnemonic="RMB", is_pseudo=True)
+        operand = PseudoOperand("$10", instruction)
+        code_pkg = operand.translate()
+        self.assertEqual("00000000000000000000000000000000", code_pkg.additional.hex())
+
     def test_pseudo_translate_org(self):
         instruction = Instruction(mnemonic="ORG", is_pseudo=True)
         operand = PseudoOperand("$FFCC", instruction)


### PR DESCRIPTION
This PR implements an `RMB` pseudo operation. The operation will set aside the specified number of bytes at the location where it is defined. The bytes will all contain a zero value. Unit tests updated to cover the new functionality. The README file was updated to explain the new operation. Closes issue #25 
