### PR TITLE
Add ability to enter list of files to extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,14 @@ associated meta-data:
     Load Addr:  $0F00
     Exec Addr:  $0F00
     Data Len:   73 bytes
+    -- File #3 --
+    Filename:   ANOTHER
+    File Type:  Object
+    Data Type:  Binary
+    Gap Status: No Gaps
+    Load Addr:  $0C00
+    Exec Addr:  $0C00
+    Data Len:   24 bytes
 
 ## Extracting Binaries
 
@@ -347,9 +355,22 @@ To command will list the files being extracted and their status:
     Saved as HELLO.bin
     -- File #2 [WORLD] --
     Saved as WORLD.bin
+    -- File #3 [ANOTHER] --
+    Saved as ANOTHER.bin
 
 Note that no meta-data is saved with the extraction (meaning that load addresses, 
-and execute addresses are not saved in the resulting `.bin` files).
+and execute addresses are not saved in the resulting `.bin` files). If you only wish to
+extract a specific subset of files, you can provide a space-separated, case-insensitive
+list of filenames to extract with the `--files` switch:
+
+    python file_util.py --to_bin test.cas --files hello another
+
+Which will result in:
+
+    -- File #1 [HELLO] --
+    Saved as HELLO.bin
+    -- File #3 [ANOTHER] --
+    Saved as ANOTHER.bin
 
 # Common Examples
 

--- a/file_util.py
+++ b/file_util.py
@@ -35,6 +35,9 @@ def parse_arguments():
     parser.add_argument(
         "--to_bin", action="store_true", help="extracts all the files from the host file, and saves them as BIN files"
     )
+    parser.add_argument(
+        "--files", nargs="+", type=str, help="list of file names to extract"
+    )
     return parser.parse_args()
 
 
@@ -62,6 +65,7 @@ def main(args):
     :param args: the command-line arguments
     """
     host_file = open_file(args.host_filename)
+    files_to_include = [x.upper() for x in args.files] if args.files else None
     if not host_file:
         print("Unable to determine file type for file [{}]".format(args.host_filename))
         sys.exit(1)
@@ -75,17 +79,18 @@ def main(args):
     if args.to_bin:
         for number, file in enumerate(host_file.list_files()):
             filename = file.name.strip().replace("\0", "")
-            binary_file_name = "{}.bin".format(filename)
-            print("-- File #{} [{}] --".format(number+1, filename))
-            try:
-                binary_file = BinaryFile()
-                binary_file.open_host_file_for_write(binary_file_name, append=args.append)
-                binary_file.save_to_host_file(file)
-                binary_file.close_host_file()
-                print("Saved as {}".format(binary_file_name))
-            except ValueError as error:
-                print("Unable to save binary file [{}]:".format(binary_file_name))
-                print(error)
+            if files_to_include is None or filename in files_to_include:
+                binary_file_name = "{}.bin".format(filename)
+                print("-- File #{} [{}] --".format(number+1, filename))
+                try:
+                    binary_file = BinaryFile()
+                    binary_file.open_host_file_for_write(binary_file_name, append=args.append)
+                    binary_file.save_to_host_file(file)
+                    binary_file.close_host_file()
+                    print("Saved as {}".format(binary_file_name))
+                except ValueError as error:
+                    print("Unable to save binary file [{}]:".format(binary_file_name))
+                    print(error)
 
 # M A I N #####################################################################
 


### PR DESCRIPTION
This PR adds the ability to specify what files you wish to extract using a `--files` command-line switch to the `file_util.py` file. The switch accepts a space-separated, case-insensitive list of files. Manual testing completed. Updated `README.md` to reflect new functionality. Closes issue #11 
