### PR TITLE
Add ability to list contents of JV1 disks and extract binaries to CAS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@
    4. [Addressing Modes](#addressing-modes)
 6. [File Utility](#file-utility)
    1. [Listing Files](#listing-files)
-   2. [Extracting Binaries](#extracting-binaries)
-6. [Common Examples](#common-examples)
+   2. [Extracting to Binary File](#extracting-to-binary-file)
+   3. [Extracting to Cassette File](#extracting-to-cassette-file)
+7. [Common Examples](#common-examples)
    1. [Appending to a Cassette](#appending-to-a-cassette)
    2. [Listing Files in an Image](#listing-files-in-an-image)
    3. [Extracting Binary Files from Cassette Images](#extracting-binary-files-from-cassette-images)
+   3. [Extracting Binary Files from Disk Images](#extracting-binary-files-from-disk-images)
 
 # What is it?
 
@@ -342,9 +344,9 @@ associated meta-data:
     Exec Addr:  $0C00
     Data Len:   24 bytes
 
-## Extracting Binaries
+## Extracting to Binary File
 
-To extract the files from a disk image, and save each one as a binary, use the
+To extract the files from a disk or cassette image, and save each one as a binary, use the
 `--to_bin` switch:
 
     python file_util.py --to_bin test.cas
@@ -372,6 +374,34 @@ Which will result in:
     -- File #3 [ANOTHER] --
     Saved as ANOTHER.bin
 
+## Extracting to Cassette File
+
+To extract the files from a disk image, and save each one as a cassette file, use the
+`--to_cas` switch:
+
+    python file_util.py --to_cas test.dsk
+    
+To command will list the files being extracted and their status:
+
+    -- File #1 [HELLO] --
+    Saved as HELLO.cas
+    -- File #2 [WORLD] --
+    Saved as WORLD.cas
+    -- File #3 [ANOTHER] --
+    Saved as ANOTHER.cas
+
+If you only wish to extract a specific subset of files, you can provide a space-separated, 
+case-insensitive list of filenames to extract with the `--files` switch:
+
+    python file_util.py --to_cas test.dsk --files hello another
+
+Which will result in:
+
+    -- File #1 [HELLO] --
+    Saved as HELLO.cas
+    -- File #3 [ANOTHER] --
+    Saved as ANOTHER.cas
+    
 # Common Examples
 
 Below are a collection of common examples with their command-line usage.
@@ -400,5 +430,15 @@ To extract all the binary files from a cassette image:
     python file_util.py --to_bin my_cassette.cas
     
 Will extract all of the files in the image file `my_cassette.bin` to separate
+files ending in a `.bin` extension. No meta-information about the files will
+be saved in `.bin` format.
+
+## Extracting Binary Files from Disk Images
+
+To extract all the binary files from a disk image:
+
+    python file_util.py --to_bin my_disk.dsk
+    
+Will extract all of the files in the image file `my_disk.dsk` to separate
 files ending in a `.bin` extension. No meta-information about the files will
 be saved in `.bin` format.

--- a/cocoasm/virtualfiles/cassette.py
+++ b/cocoasm/virtualfiles/cassette.py
@@ -6,10 +6,7 @@ A Color Computer Assembler - see the README.md file for details.
 """
 # I M P O R T S ###############################################################
 
-import sys
-
 from enum import IntEnum
-
 
 from cocoasm.virtualfiles.virtualfile import VirtualFile, CoCoFile
 from cocoasm.values import Value

--- a/cocoasm/virtualfiles/disk.py
+++ b/cocoasm/virtualfiles/disk.py
@@ -8,12 +8,24 @@ A Color Computer Assembler - see the README.md file for details.
 
 from cocoasm.virtualfiles.virtualfile import VirtualFile, CoCoFile
 from cocoasm.values import Value
+from typing import NamedTuple
 
 # C L A S S E S ###############################################################
 
 
+class Preamble(NamedTuple):
+    load_addr: Value = None
+    data_length: Value = None
+
+
+class Postamble(NamedTuple):
+    exec_addr: Value = None
+
+
 class DiskFile(VirtualFile):
-    FAT_OFFSET = 78848
+    FAT_OFFSET = 78592
+    DIR_OFFSET = 78848
+    HALF_TRACK_LEN = 2304
 
     def __init__(self):
         super().__init__()
@@ -32,24 +44,109 @@ class DiskFile(VirtualFile):
 
     def list_files(self, filenames=None):
         files = []
-        self.host_file.seek(DiskFile.FAT_OFFSET)
+        fat = []
+
+        # Read the File Allocation Table
+        self.host_file.seek(DiskFile.FAT_OFFSET, 0)
+        fat = self.host_file.read(256)
+
+        # Move through elements in the Directory Table and read them into CoCoFile objects
+        self.host_file.seek(DiskFile.DIR_OFFSET, 0)
         for file_number in range(0, 72):
             next_byte = Value.create_from_byte(self.host_file.peek(1)[:1])
             if next_byte.hex() == "00" or next_byte.hex() == "FF":
                 self.host_file.seek(32, 1)
             else:
+                name = "{}.{}".format(
+                    self.host_file.read(8).decode("utf-8").replace(" ", ""),
+                    self.host_file.read(3).decode("utf-8")
+                )
+                file_type = Value.create_from_byte(self.host_file.read(1))
+                data_type = Value.create_from_byte(self.host_file.read(1))
+                starting_granule = Value.create_from_byte(self.host_file.read(1))
+                current_location = self.host_file.tell()
+                preamble = DiskFile.read_preamble(self.host_file, starting_granule.int)
+                print("preamble data length: {}".format(preamble.data_length.hex()))
+                file_data = self.read_data(
+                    self.host_file,
+                    starting_granule.int,
+                    has_preamble=True,
+                    data_length=preamble.data_length.int,
+                    fat=fat,
+                )
+                postamble = DiskFile.read_postamble(self.host_file)
+                self.host_file.seek(current_location, 0)
                 coco_file = CoCoFile(
-                    name="{}.{}".format(self.host_file.read(8).decode("utf-8"), self.host_file.read(3).decode("utf-8")),
-                    type=Value.create_from_byte(self.host_file.read(1)),
-                    data_type=Value.create_from_byte(self.host_file.read(1)),
-                    load_addr=Value.create_from_byte(b"0"),
-                    exec_addr=Value.create_from_byte(b"0"),
+                    name=name,
+                    type=file_type,
+                    data_type=data_type,
+                    load_addr=preamble.load_addr,
+                    exec_addr=postamble.exec_addr,
+                    data=file_data,
                     ignore_gaps=True
                 )
                 files.append(coco_file)
                 self.host_file.seek(19, 1)
 
         return files
+
+    @classmethod
+    def seek_granule(cls, file, granule):
+        granule_offset = DiskFile.HALF_TRACK_LEN * granule
+        if granule > 33:
+            granule_offset += DiskFile.HALF_TRACK_LEN * 2
+        file.seek(granule_offset, 0)
+
+    @classmethod
+    def read_preamble(cls, file, starting_granule):
+        DiskFile.seek_granule(file, starting_granule)
+        preamble_flag = Value.create_from_byte(file.read(1))
+        if preamble_flag.hex() != "00":
+            raise ValueError("Invalid preamble flag {}".format(preamble_flag.hex()))
+        return Preamble(
+            data_length=Value.create_from_byte(file.read(2)),
+            load_addr=Value.create_from_byte(file.read(2))
+        )
+
+    @classmethod
+    def read_postamble(cls, file):
+        """
+        Reads the post-amble of a binary file.
+        :param file:
+        :return:
+        """
+        postamble_flag = Value.create_from_byte(file.read(1))
+        if postamble_flag.hex() != "FF":
+            raise ValueError("Invalid first postamble flag {}".format(postamble_flag.hex()))
+        postamble_flag = Value.create_from_byte(file.read(2))
+        if postamble_flag.hex() != "00":
+            raise ValueError("Invalid second postamble flag {}".format(postamble_flag.hex()))
+        return Postamble(
+            exec_addr=Value.create_from_byte(file.read(2)),
+        )
+
+    @classmethod
+    def read_data(cls, file, starting_granule, has_preamble=False, data_length=0, fat=[]):
+        DiskFile.seek_granule(file, starting_granule)
+        file_data = []
+        chunk_size = DiskFile.HALF_TRACK_LEN
+
+        # Skip over preamble if it exists
+        if has_preamble:
+            file.read(5)
+            chunk_size -= 5
+
+        # Check to see if we are reading more than one granule
+        if data_length > chunk_size:
+            for _ in range(chunk_size):
+                file_data.append(file.read(1))
+                data_length -= 1
+            next_granule = fat[starting_granule]
+            file_data.extend(DiskFile.read_data(file, next_granule, data_length=data_length, fat=fat))
+        else:
+            for _ in range(data_length):
+                file_data.append(file.read(1))
+        return file_data
 
     def save_to_host_file(self, coco_file):
         pass

--- a/cocoasm/virtualfiles/disk.py
+++ b/cocoasm/virtualfiles/disk.py
@@ -6,19 +6,52 @@ A Color Computer Assembler - see the README.md file for details.
 """
 # I M P O R T S ###############################################################
 
-from cocoasm.virtualfiles.virtualfile import VirtualFile
+from cocoasm.virtualfiles.virtualfile import VirtualFile, CoCoFile
+from cocoasm.values import Value
 
 # C L A S S E S ###############################################################
 
 
 class DiskFile(VirtualFile):
+    FAT_OFFSET = 78848
+
     def __init__(self):
         super().__init__()
+        self.raw_data = []
 
-    def list_files(self):
-        pass
+    def is_correct_type(self):
+        if not self.host_file:
+            raise ValueError("No file currently open")
 
-    def save_to_host_file(self, name, raw_bytes):
+        if not self.read_mode:
+            raise ValueError("[{}] not open for reading".format(self.filename))
+
+        self.host_file.seek(0, 2)
+        size = self.host_file.tell()
+        return True if size == 161280 else False
+
+    def list_files(self, filenames=None):
+        files = []
+        self.host_file.seek(DiskFile.FAT_OFFSET)
+        for file_number in range(0, 72):
+            next_byte = Value.create_from_byte(self.host_file.peek(1)[:1])
+            if next_byte.hex() == "00" or next_byte.hex() == "FF":
+                self.host_file.seek(32, 1)
+            else:
+                coco_file = CoCoFile(
+                    name="{}.{}".format(self.host_file.read(8).decode("utf-8"), self.host_file.read(3).decode("utf-8")),
+                    type=Value.create_from_byte(self.host_file.read(1)),
+                    data_type=Value.create_from_byte(self.host_file.read(1)),
+                    load_addr=Value.create_from_byte(b"0"),
+                    exec_addr=Value.create_from_byte(b"0"),
+                    ignore_gaps=True
+                )
+                files.append(coco_file)
+                self.host_file.seek(19, 1)
+
+        return files
+
+    def save_to_host_file(self, coco_file):
         pass
 
 # E N D   O F   F I L E #######################################################

--- a/cocoasm/virtualfiles/virtualfile.py
+++ b/cocoasm/virtualfiles/virtualfile.py
@@ -30,6 +30,7 @@ class CoCoFile(NamedTuple):
     gaps: Value = None
     ascii: int = 0
     data: list = []
+    ignore_gaps: bool = False
 
     def __str__(self):
         result = "Filename:   {}\n".format(self.name)
@@ -38,6 +39,8 @@ class CoCoFile(NamedTuple):
             filetype = "Data"
         if self.type.hex() == "02":
             filetype = "Object"
+        if self.type.hex() == "03":
+            filetype = "Text"
         result += "File Type:  {}\n".format(filetype)
 
         data_type = "Binary"
@@ -45,10 +48,11 @@ class CoCoFile(NamedTuple):
             data_type = "ASCII"
         result += "Data Type:  {}\n".format(data_type)
 
-        gaps = "No Gaps"
-        if self.gaps.hex() == "FF":
-            gaps = "Gaps"
-        result += "Gap Status: {}\n".format(gaps)
+        if not self.ignore_gaps:
+            gaps = "No Gaps"
+            if self.gaps.hex() == "FF":
+                gaps = "Gaps"
+            result += "Gap Status: {}\n".format(gaps)
 
         result += "Load Addr:  ${}\n".format(self.load_addr.hex(size=4))
         result += "Exec Addr:  ${}\n".format(self.exec_addr.hex(size=4))

--- a/cocoasm/virtualfiles/virtualfile.py
+++ b/cocoasm/virtualfiles/virtualfile.py
@@ -23,6 +23,7 @@ class CoCoFile(NamedTuple):
     execution point, the name, type, etc.
     """
     name: str = ""
+    extension: str = ""
     type: Value = None
     load_addr: Value = None
     exec_addr: Value = None
@@ -34,6 +35,7 @@ class CoCoFile(NamedTuple):
 
     def __str__(self):
         result = "Filename:   {}\n".format(self.name)
+        result += "Extension:  {}\n".format(self.extension)
         filetype = "BASIC"
         if self.type.hex() == "01":
             filetype = "Data"

--- a/file_util.py
+++ b/file_util.py
@@ -11,6 +11,7 @@ import sys
 
 from cocoasm.virtualfiles.binary import BinaryFile
 from cocoasm.virtualfiles.cassette import CassetteFile
+from cocoasm.virtualfiles.disk import DiskFile
 
 # F U N C T I O N S ###########################################################
 
@@ -51,6 +52,11 @@ def open_file(filename):
     :return: the opened host file or None
     """
     file = CassetteFile()
+    file.open_host_file_for_read(filename)
+    if file.is_correct_type():
+        return file
+
+    file = DiskFile()
     file.open_host_file_for_read(filename)
     if file.is_correct_type():
         return file

--- a/file_util.py
+++ b/file_util.py
@@ -37,6 +37,9 @@ def parse_arguments():
         "--to_bin", action="store_true", help="extracts all the files from the host file, and saves them as BIN files"
     )
     parser.add_argument(
+        "--to_cas", action="store_true", help="extracts all the files from the host file, and saves them as CAS files"
+    )
+    parser.add_argument(
         "--files", nargs="+", type=str, help="list of file names to extract"
     )
     return parser.parse_args()
@@ -96,6 +99,22 @@ def main(args):
                     print("Saved as {}".format(binary_file_name))
                 except ValueError as error:
                     print("Unable to save binary file [{}]:".format(binary_file_name))
+                    print(error)
+
+    if args.to_cas:
+        for number, file in enumerate(host_file.list_files()):
+            filename = file.name.strip().replace("\0", "")
+            if files_to_include is None or filename in files_to_include:
+                cas_file_name = "{}.cas".format(filename)
+                print("-- File #{} [{}] --".format(number + 1, filename))
+                try:
+                    cas_file = CassetteFile()
+                    cas_file.open_host_file_for_write(cas_file_name, append=args.append)
+                    cas_file.save_to_host_file(file)
+                    cas_file.close_host_file()
+                    print("Saved as {}".format(cas_file_name))
+                except ValueError as error:
+                    print("Unable to save cassette file [{}]:".format(cas_file_name))
                     print(error)
 
 # M A I N #####################################################################


### PR DESCRIPTION
This PR adds the ability to list the files contained within a JV1 style DSK image. In addition, the file utility was updated to allow users to extract binary files from the disk image and save them as individual CAS images. Note that only binary file types work correctly with the extraction at the moment. `README.md` was updated to reflect new functionality.