### PR TITLE
Fix various assembly problems

### DIFF
--- a/cocoasm/exceptions.py
+++ b/cocoasm/exceptions.py
@@ -36,4 +36,20 @@ class ParseError(Exception):
     def __str__(self):
         return repr(self.value)
 
+
+class ValueTypeError(Exception):
+    """
+    ValueTypeErrors are raised when generating or manipulating anything of
+    the Value class.
+    """
+    pass
+
+
+class OperandTypeError(Exception):
+    """
+    OperandTypeErrors are raised when generating or manipulating any type of
+    Operand class.
+    """
+    pass
+
 # E N D   O F   F I L E #######################################################

--- a/cocoasm/instruction.py
+++ b/cocoasm/instruction.py
@@ -14,12 +14,13 @@ from cocoasm.values import NoneValue
 # C L A S S E S ###############################################################
 
 class CodePackage(object):
-    def __init__(self, op_code=NoneValue(), address=NoneValue(), post_byte=NoneValue(), additional=NoneValue(), size=0):
+    def __init__(self, op_code=NoneValue(), address=NoneValue(), post_byte=NoneValue(), additional=NoneValue(), size=0, additional_needs_resolution=False):
         self.op_code = op_code
         self.address = address
         self.post_byte = post_byte
         self.additional = additional
         self.size = size
+        self.additional_needs_resolution = additional_needs_resolution
 
 
 class Mode(NamedTuple):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,0 +1,60 @@
+"""
+Copyright (C) 2019-2021 Craig Thomas
+
+This project uses an MIT style license - see LICENSE for details.
+This file contains the main Program class for the CoCo Assembler.
+"""
+# I M P O R T S ###############################################################
+
+import unittest
+
+from unittest.mock import patch, call
+
+from cocoasm.program import Program
+from cocoasm.statement import Statement
+from cocoasm.exceptions import TranslationError
+from cocoasm.values import NumericValue
+
+# C L A S S E S ###############################################################
+
+
+class TestIntegration(unittest.TestCase):
+    """
+    Integration tests.
+    """
+    def setUp(self):
+        """
+        Common setup routines needed for all unit tests.
+        """
+
+    def test_expression_addition_with_address_on_left(self):
+        statements = [
+            Statement("     ORG $0E00"),
+            Statement("V    STX R+1"),
+            Statement("R    FCB 0"),
+            Statement("     FCB 0"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xBF, 0x0E, 0x04, 0x00, 0x00], program.get_binary_array())
+
+    def test_expression_subtraction_with_address_on_left(self):
+        statements = [
+            Statement("     ORG $0E00"),
+            Statement("V    STX R-1"),
+            Statement("     FCB 0"),
+            Statement("R    FCB 0"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xBF, 0x0E, 0x03, 0x00, 0x00], program.get_binary_array())
+
+# M A I N #####################################################################
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# E N D   O F   F I L E #######################################################

--- a/test/test_program.py
+++ b/test/test_program.py
@@ -167,8 +167,8 @@ class TestProgram(unittest.TestCase):
         program.statements = [statement1]
         self.assertEqual([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE], program.get_binary_array())
 
-
 # M A I N #####################################################################
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes several problems and refactors the code in fairly significant ways to make things work properly:

* The `ExpressionOperand` was refactored into an `ExpressionValue` since all types of operands can contain expressions. This was done because it makes sense to resolve the expression within the value rather than resolving an operand type that would then have to figure out what other operand type it should be promoted to (e.g. why create an `ExpressionOperand` that then has to switch itself to `ImmediateOperand` - it makes more sense to have an `ImmediateOperand` with an `ExpressionValue` instead).
* The change to expressions fixed instances where some expressions were not being resolved correctly (e.g. `STX #VAR+1` would not be assembled correctly).
* `DirectOperand` and `ExtendedOperand` are now resolved later. If the type of operand cannot be initially determined when instantiated, an `UnknownOperand` is generated first. When symbol resolution is complete, the `UnknownOperand` is then promoted to either `DirectOperand` or `ExtendedOperand`. This makes for a much cleaner implementation, since the code before was attempting to guess what type it should be before symbol resolution was complete.
* Extended indexed and indexed operations are changed to allow for addresses on the left hand side.
* Proper exception classes were created for operands and values. This was to avoid confusion when performing object creations from strings, since both types of objects would raise `ValueError` exceptions when there were errors and the overarching code couldn't determine whether an operand or value was a problem.

Unit tests updated to match new functionality. New integration tests added to cover fixed bug examples to prevent regressions.