### PR TITLE
Program Counter Relative addressing 8-bit fix

### DIFF
--- a/cocoasm/instruction.py
+++ b/cocoasm/instruction.py
@@ -14,13 +14,25 @@ from cocoasm.values import NoneValue
 # C L A S S E S ###############################################################
 
 class CodePackage(object):
-    def __init__(self, op_code=NoneValue(), address=NoneValue(), post_byte=NoneValue(), additional=NoneValue(), size=0, additional_needs_resolution=False):
+    def __init__(self,
+                 op_code=NoneValue(),
+                 address=NoneValue(),
+                 post_byte=NoneValue(),
+                 additional=NoneValue(),
+                 size=0,
+                 additional_needs_resolution=False,
+                 post_byte_choices=None,
+                 max_size=0,
+                 ):
+        post_byte_choices = [] if post_byte_choices is None else post_byte_choices
         self.op_code = op_code
         self.address = address
         self.post_byte = post_byte
         self.additional = additional
         self.size = size
         self.additional_needs_resolution = additional_needs_resolution
+        self.post_byte_choices = post_byte_choices
+        self.max_size = max_size
 
 
 class Mode(NamedTuple):

--- a/cocoasm/operands.py
+++ b/cocoasm/operands.py
@@ -203,19 +203,23 @@ class PseudoOperand(Operand):
 
     def translate(self):
         if self.instruction.mnemonic == "FCB":
-            return CodePackage(additional=self.value, size=1)
+            return CodePackage(additional=self.value, size=1, max_size=1)
 
         if self.instruction.mnemonic == "FDB":
-            return CodePackage(additional=NumericValue(self.value.int, size_hint=4), size=2)
+            return CodePackage(additional=NumericValue(self.value.int, size_hint=4), size=2, max_size=2)
 
         if self.instruction.mnemonic == "RMB":
-            return CodePackage(additional=NumericValue(0, size_hint=self.value.int*2), size=self.value.int)
+            return CodePackage(
+                additional=NumericValue(0, size_hint=self.value.int*2),
+                size=self.value.int,
+                max_size=self.value.int,
+            )
 
         if self.instruction.mnemonic == "ORG":
             return CodePackage(address=self.value)
 
         if self.instruction.mnemonic == "FCC":
-            return CodePackage(additional=self.value, size=self.value.byte_len())
+            return CodePackage(additional=self.value, size=self.value.byte_len(), max_size=self.value.byte_len())
 
         return CodePackage()
 
@@ -232,10 +236,7 @@ class SpecialOperand(Operand):
         return self
 
     def translate(self):
-        code_pkg = CodePackage()
-        code_pkg.op_code = NumericValue(self.instruction.mode.imm)
-        code_pkg.size = self.instruction.mode.imm_sz
-        code_pkg.post_byte = 0x00
+        post_byte = 0x00
 
         if self.instruction.mnemonic == "PSHS" or self.instruction.mnemonic == "PULS":
             if not self.operand_string:
@@ -246,15 +247,15 @@ class SpecialOperand(Operand):
                 if register not in REGISTERS:
                     raise OperandTypeError("[{}] unknown register".format(register))
 
-                code_pkg.post_byte |= 0x06 if register == "D" else 0x00
-                code_pkg.post_byte |= 0x01 if register == "CC" else 0x00
-                code_pkg.post_byte |= 0x02 if register == "A" else 0x00
-                code_pkg.post_byte |= 0x04 if register == "B" else 0x00
-                code_pkg.post_byte |= 0x08 if register == "DP" else 0x00
-                code_pkg.post_byte |= 0x10 if register == "X" else 0x00
-                code_pkg.post_byte |= 0x20 if register == "Y" else 0x00
-                code_pkg.post_byte |= 0x40 if register == "U" else 0x00
-                code_pkg.post_byte |= 0x80 if register == "PC" else 0x00
+                post_byte |= 0x06 if register == "D" else 0x00
+                post_byte |= 0x01 if register == "CC" else 0x00
+                post_byte |= 0x02 if register == "A" else 0x00
+                post_byte |= 0x04 if register == "B" else 0x00
+                post_byte |= 0x08 if register == "DP" else 0x00
+                post_byte |= 0x10 if register == "X" else 0x00
+                post_byte |= 0x20 if register == "Y" else 0x00
+                post_byte |= 0x40 if register == "U" else 0x00
+                post_byte |= 0x80 if register == "PC" else 0x00
 
         if self.instruction.mnemonic == "EXG" or self.instruction.mnemonic == "TFR":
             registers = self.operand_string.split(",")
@@ -267,37 +268,37 @@ class SpecialOperand(Operand):
             if registers[1] not in REGISTERS:
                 raise OperandTypeError("[{}] unknown register".format(registers[1]))
 
-            code_pkg.post_byte |= 0x00 if registers[0] == "D" else 0x00
-            code_pkg.post_byte |= 0x00 if registers[1] == "D" else 0x00
+            post_byte |= 0x00 if registers[0] == "D" else 0x00
+            post_byte |= 0x00 if registers[1] == "D" else 0x00
 
-            code_pkg.post_byte |= 0x10 if registers[0] == "X" else 0x00
-            code_pkg.post_byte |= 0x01 if registers[1] == "X" else 0x00
+            post_byte |= 0x10 if registers[0] == "X" else 0x00
+            post_byte |= 0x01 if registers[1] == "X" else 0x00
 
-            code_pkg.post_byte |= 0x20 if registers[0] == "Y" else 0x00
-            code_pkg.post_byte |= 0x02 if registers[1] == "Y" else 0x00
+            post_byte |= 0x20 if registers[0] == "Y" else 0x00
+            post_byte |= 0x02 if registers[1] == "Y" else 0x00
 
-            code_pkg.post_byte |= 0x30 if registers[0] == "U" else 0x00
-            code_pkg.post_byte |= 0x03 if registers[1] == "U" else 0x00
+            post_byte |= 0x30 if registers[0] == "U" else 0x00
+            post_byte |= 0x03 if registers[1] == "U" else 0x00
 
-            code_pkg.post_byte |= 0x40 if registers[0] == "S" else 0x00
-            code_pkg.post_byte |= 0x04 if registers[1] == "S" else 0x00
+            post_byte |= 0x40 if registers[0] == "S" else 0x00
+            post_byte |= 0x04 if registers[1] == "S" else 0x00
 
-            code_pkg.post_byte |= 0x50 if registers[0] == "PC" else 0x00
-            code_pkg.post_byte |= 0x05 if registers[1] == "PC" else 0x00
+            post_byte |= 0x50 if registers[0] == "PC" else 0x00
+            post_byte |= 0x05 if registers[1] == "PC" else 0x00
 
-            code_pkg.post_byte |= 0x80 if registers[0] == "A" else 0x00
-            code_pkg.post_byte |= 0x08 if registers[1] == "A" else 0x00
+            post_byte |= 0x80 if registers[0] == "A" else 0x00
+            post_byte |= 0x08 if registers[1] == "A" else 0x00
 
-            code_pkg.post_byte |= 0x90 if registers[0] == "B" else 0x00
-            code_pkg.post_byte |= 0x09 if registers[1] == "B" else 0x00
+            post_byte |= 0x90 if registers[0] == "B" else 0x00
+            post_byte |= 0x09 if registers[1] == "B" else 0x00
 
-            code_pkg.post_byte |= 0xA0 if registers[0] == "CC" else 0x00
-            code_pkg.post_byte |= 0x0A if registers[1] == "CC" else 0x00
+            post_byte |= 0xA0 if registers[0] == "CC" else 0x00
+            post_byte |= 0x0A if registers[1] == "CC" else 0x00
 
-            code_pkg.post_byte |= 0xB0 if registers[0] == "DP" else 0x00
-            code_pkg.post_byte |= 0x0B if registers[1] == "DP" else 0x00
+            post_byte |= 0xB0 if registers[0] == "DP" else 0x00
+            post_byte |= 0x0B if registers[1] == "DP" else 0x00
 
-            if code_pkg.post_byte not in \
+            if post_byte not in \
                     [
                         0x01, 0x10, 0x02, 0x20, 0x03, 0x30, 0x04, 0x40,
                         0x05, 0x50, 0x12, 0x21, 0x13, 0x31, 0x14, 0x41,
@@ -310,8 +311,12 @@ class SpecialOperand(Operand):
                 raise OperandTypeError(
                     "[{}] of [{}] to [{}] not allowed".format(self.instruction.mnemonic, registers[0], registers[1]))
 
-        code_pkg.post_byte = NumericValue(code_pkg.post_byte)
-        return code_pkg
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.imm),
+            post_byte=NumericValue(post_byte),
+            size=self.instruction.mode.imm_sz,
+            max_size=self.instruction.mode.imm_sz,
+        )
 
 
 class RelativeOperand(Operand):
@@ -324,12 +329,12 @@ class RelativeOperand(Operand):
         self.value = value if value else Value.create_from_str(operand_string, instruction)
 
     def translate(self):
-        code_pkg = CodePackage()
-        code_pkg.op_code = NumericValue(self.instruction.mode.rel)
-        if self.value.is_type(ValueType.ADDRESS):
-            code_pkg.additional = self.value
-        code_pkg.size = self.instruction.mode.rel_sz
-        return code_pkg
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.rel),
+            additional=self.value if self.value.is_type(ValueType.ADDRESS) else NoneValue(),
+            size=self.instruction.mode.rel_sz,
+            max_size=self.instruction.mode.rel_sz,
+        )
 
 
 class InherentOperand(Operand):
@@ -344,7 +349,11 @@ class InherentOperand(Operand):
     def translate(self):
         if not self.instruction.mode.inh:
             raise OperandTypeError("Instruction [{}] requires an operand".format(self.instruction.mnemonic))
-        return CodePackage(op_code=NumericValue(self.instruction.mode.inh), size=self.instruction.mode.inh_sz)
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.inh),
+            size=self.instruction.mode.inh_sz,
+            max_size=self.instruction.mode.inh_sz,
+        )
 
 
 class ImmediateOperand(Operand):
@@ -362,10 +371,15 @@ class ImmediateOperand(Operand):
 
     def translate(self):
         if not self.instruction.mode.imm:
-            raise OperandTypeError("Instruction [{}] does not support immediate addressing".format(self.instruction.mnemonic))
-        return CodePackage(op_code=NumericValue(self.instruction.mode.imm),
-                           additional=self.value,
-                           size=self.instruction.mode.imm_sz)
+            raise OperandTypeError(
+                "Instruction [{}] does not support immediate addressing".format(self.instruction.mnemonic)
+            )
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.imm),
+            additional=self.value,
+            size=self.instruction.mode.imm_sz,
+            max_size=self.instruction.mode.imm_sz,
+        )
 
 
 class DirectOperand(Operand):
@@ -388,10 +402,15 @@ class DirectOperand(Operand):
 
     def translate(self):
         if not self.instruction.mode.dir:
-            raise OperandTypeError("Instruction [{}] does not support direct addressing".format(self.instruction.mnemonic))
-        return CodePackage(op_code=NumericValue(self.instruction.mode.dir),
-                           additional=self.value,
-                           size=self.instruction.mode.dir_sz)
+            raise OperandTypeError(
+                "Instruction [{}] does not support direct addressing".format(self.instruction.mnemonic)
+            )
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.dir),
+            additional=self.value,
+            size=self.instruction.mode.dir_sz,
+            max_size=self.instruction.mode.dir_sz,
+        )
 
 
 class ExtendedOperand(Operand):
@@ -410,10 +429,15 @@ class ExtendedOperand(Operand):
 
     def translate(self):
         if not self.instruction.mode.ext:
-            raise OperandTypeError("Instruction [{}] does not support extended addressing".format(self.instruction.mnemonic))
-        return CodePackage(op_code=NumericValue(self.instruction.mode.ext),
-                           additional=self.value,
-                           size=self.instruction.mode.ext_sz)
+            raise OperandTypeError(
+                "Instruction [{}] does not support extended addressing".format(self.instruction.mnemonic)
+            )
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.ext),
+            additional=self.value,
+            size=self.instruction.mode.ext_sz,
+            max_size=self.instruction.mode.ext_sz,
+        )
 
 
 class ExtendedIndexedOperand(Operand):
@@ -451,7 +475,9 @@ class ExtendedIndexedOperand(Operand):
 
     def translate(self):
         if not self.instruction.mode.ind:
-            raise OperandTypeError("Instruction [{}] does not support indexed addressing".format(self.instruction.mnemonic))
+            raise OperandTypeError(
+                "Instruction [{}] does not support indexed addressing".format(self.instruction.mnemonic)
+            )
         size = self.instruction.mode.ind_sz
 
         if not type(self.value) == str and self.value.is_type(ValueType.ADDRESS):
@@ -460,7 +486,9 @@ class ExtendedIndexedOperand(Operand):
                 op_code=NumericValue(self.instruction.mode.ind),
                 post_byte=NumericValue(0x9F),
                 additional=self.value,
-                size=size)
+                size=size,
+                max_size=size,
+            )
 
         if not type(self.value) == str and self.value.is_type(ValueType.NUMERIC):
             size += 2
@@ -468,7 +496,9 @@ class ExtendedIndexedOperand(Operand):
                 op_code=NumericValue(self.instruction.mode.ind),
                 post_byte=NumericValue(0x9F),
                 additional=self.value,
-                size=size)
+                size=size,
+                max_size=size,
+            )
 
         raw_post_byte = 0x80
         additional = NoneValue()
@@ -526,11 +556,14 @@ class ExtendedIndexedOperand(Operand):
                 size += additional.byte_len()
                 raw_post_byte |= 0x99 if additional.byte_len() == 2 else 0x98
 
-        return CodePackage(op_code=NumericValue(self.instruction.mode.ind),
-                           post_byte=NumericValue(raw_post_byte),
-                           additional=additional,
-                           size=size,
-                           additional_needs_resolution=additional_needs_resolution)
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.ind),
+            post_byte=NumericValue(raw_post_byte),
+            additional=additional,
+            size=size,
+            max_size=size,
+            additional_needs_resolution=additional_needs_resolution,
+        )
 
 
 class IndexedOperand(Operand):
@@ -556,9 +589,13 @@ class IndexedOperand(Operand):
 
     def translate(self):
         if not self.instruction.mode.ind:
-            raise OperandTypeError("Instruction [{}] does not support indexed addressing".format(self.instruction.mnemonic))
+            raise OperandTypeError(
+                "Instruction [{}] does not support indexed addressing".format(self.instruction.mnemonic)
+            )
         raw_post_byte = 0x00
+        post_byte_choices = []
         size = self.instruction.mode.ind_sz
+        max_size = size
         additional = NoneValue()
         additional_needs_resolution = False
 
@@ -607,25 +644,31 @@ class IndexedOperand(Operand):
             additional = self.left
 
             if "PCR" in self.right:
-                # TODO: all address symbols resolve to 16-bit offsets, need to find a way to calculate 8-bit offsets
                 if additional_needs_resolution:
-                    size += 2
-                    raw_post_byte |= 0x8D
+                    raw_post_byte |= 0x00
+                    post_byte_choices = [0x8C, 0x8D]
+                    max_size += 2
                 else:
                     size += additional.byte_len()
+                    max_size = size
                     raw_post_byte |= 0x8D if additional.byte_len() == 2 else 0x8C
             else:
                 if additional.int <= 0x1F:
                     raw_post_byte |= additional.int
                 else:
                     size += additional.byte_len()
+                    max_size = size
                     raw_post_byte |= 0x89 if additional.byte_len() == 2 else 0x88
 
-        return CodePackage(op_code=NumericValue(self.instruction.mode.ind),
-                           post_byte=NumericValue(raw_post_byte),
-                           additional=additional,
-                           size=size,
-                           additional_needs_resolution=additional_needs_resolution)
+        return CodePackage(
+            op_code=NumericValue(self.instruction.mode.ind),
+            post_byte=NumericValue(raw_post_byte),
+            additional=additional,
+            size=size,
+            additional_needs_resolution=additional_needs_resolution,
+            post_byte_choices=post_byte_choices,
+            max_size=max_size,
+        )
 
 
 # E N D   O F   F I L E #######################################################

--- a/cocoasm/program.py
+++ b/cocoasm/program.py
@@ -120,6 +120,10 @@ class Program(object):
             for index, statement in enumerate(self.statements):
                 statement.translate()
 
+            # Check for any PCR indexed addresses, and flag them
+            for index, statement in enumerate(self.statements):
+                statement.fix_pcr_relative_addresses(self.statements, index)
+
             address = 0
             for index, statement in enumerate(self.statements):
                 address = statement.set_address(address)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -51,6 +51,86 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0xBF, 0x0E, 0x03, 0x00, 0x00], program.get_binary_array())
 
+    def test_program_counter_relative_8_bit_offset_reverse(self):
+        statements = [
+            Statement("     ORG $0600"),
+            Statement("V    FCB 0"),
+            Statement("B    LDA $FF"),
+            Statement("     STY V,PCR"),
+            Statement("     END B"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x00, 0x96, 0xFF, 0x10, 0xAF, 0x8C, 0xF9], program.get_binary_array())
+
+    def test_program_counter_relative_8_bit_offset_forward(self):
+        statements = [
+            Statement("     ORG $0600"),
+            Statement("B    LDA $FF"),
+            Statement("     STY V,PCR"),
+            Statement("     INCA "),
+            Statement("V    FCB 0"),
+            Statement("     END B"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x96, 0xFF, 0x10, 0xAF, 0x8C, 0x01, 0x4C, 0x00], program.get_binary_array())
+
+    def test_program_counter_relative_8_bit_offset_extended_reverse(self):
+        statements = [
+            Statement("     ORG $0600"),
+            Statement("V    FCB 0"),
+            Statement("B    LDA $FF"),
+            Statement("     STY [V,PCR]"),
+            Statement("     END B"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x00, 0x96, 0xFF, 0x10, 0xAF, 0x9C, 0xF9], program.get_binary_array())
+
+    def test_program_counter_relative_8_bit_offset_extended_forward(self):
+        statements = [
+            Statement("     ORG $0600"),
+            Statement("B    LDA $FF"),
+            Statement("     STY [V,PCR]"),
+            Statement("     INCA "),
+            Statement("V    FCB 0"),
+            Statement("     END B"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x96, 0xFF, 0x10, 0xAF, 0x9C, 0x01, 0x4C, 0x00], program.get_binary_array())
+
+    def test_load_effective_address_program_counter_relative_is_16_bit(self):
+        statements = [
+            Statement("     ORG $0600"),
+            Statement("B    LEAX Z,PCR"),
+            Statement("     LDA $FF"),
+            Statement("Z    RTS  "),
+            Statement("     END B"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x30, 0x8D, 0x00, 0x02, 0x96, 0xFF, 0x39], program.get_binary_array())
+
+    def test_load_effective_address_program_counter_relative_extended_is_16_bit(self):
+        statements = [
+            Statement("     ORG $0600"),
+            Statement("B    LEAX [Z,PCR]"),
+            Statement("     LDA $FF"),
+            Statement("Z    RTS  "),
+            Statement("     END B"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x30, 0x9D, 0x00, 0x02, 0x96, 0xFF, 0x39], program.get_binary_array())
+
 # M A I N #####################################################################
 
 

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -83,7 +83,6 @@ class TestValue(unittest.TestCase):
 
     def test_create_from_byte_works_correctly(self):
         result = Value.create_from_byte(b"\xDE\xAD")
-        print(result.hex())
         self.assertEqual(result.int, 0xDEAD)
 
 


### PR DESCRIPTION
This PR introduces a fix for issue #37 where only 16-bit values were allowed for Program Counter relative indexed addressing. To solve the problem, a choice of two post-byte values are saved in the `CodePackage` for the indexed or extended indexed operand - one for the 8-bit version, and the other for the 16-bit version. Additionally, a new `max_size` value was added to the `CodePackage` class to account for the fact that we don't know how large the fully assembled instruction will be until it is properly resolved. The assembler then introduces a new special step called `fix_pcr_relative_addresses` that looks for any program counter relative addresses, and resolves them. Using the `max_size` values, it calculates whether the program counter relative address would be within 255 bytes, and uses the 8-bit post-byte value and a single additional byte to store the relative address. Otherwise, it uses the 16-bit post-byte value and two additional bytes to store the relative address. 

In addition to this fix, a related problem with `LEA` (Load Effective Address) operations was discovered. For any `LEA` program counter relative instruction, it should only ever use the 16-bit post-byte code and a 16-bit relative address. A special case was introduced to ensure this behavior occurs.

Unit tests were introduced to cover new code paths. Closes issue #37 