### PR TITLE
Update Statement ParseError with better context

### DIFF
--- a/test/test_statement.py
+++ b/test/test_statement.py
@@ -80,7 +80,10 @@ class TestStatement(unittest.TestCase):
     def test_parse_failure(self):
         with self.assertRaises(ParseError) as context:
             Statement("failure_to_parse")
-        self.assertEqual("'Could not parse line [failure_to_parse]'", str(context.exception))
+        self.assertEqual(
+            "failure_to_parse",
+            str(context.exception.statement)
+        )
 
     def test_str_correct(self):
         statement = Statement("LABEL JMP $FFFF ; comment")


### PR DESCRIPTION
This PR updates the parsing portion of statement so that it includes a better contextual cue when an error occurs. In the previous incarnation, parse errors with invalid values would result in unhelpful stack traces such as:

```
cocoasm.exceptions.ValueTypeError: [] is an invalid value
```

This PR updates the context so that the raw input line is displayed instead as a context, along with an error indicating there was a parsing problem. For example:

```
Invalid operand value
line: MAIN       LDA      #'C      ; Literal C
```

Unit tests updated to catch new condition.
