### PR TITLE
Implement better error handling

### DIFF
--- a/assembler.py
+++ b/assembler.py
@@ -49,6 +49,10 @@ def parse_arguments():
     parser.add_argument(
         "--append", action="store_true", help="appends to an existing cassette or disk file if it exists"
     )
+    parser.add_argument(
+        "--width", metavar="N", help="the width of the console for printing results (default=100)",
+        default=100, type=int,
+    )
     return parser.parse_args()
 
 
@@ -58,7 +62,7 @@ def main(args):
 
     :param args: the command-line arguments
     """
-    program = Program()
+    program = Program(width=args.width)
     program.process(args.filename)
     coco_file = CoCoFile(
         name=program.name or args.name,

--- a/cocoasm/statement.py
+++ b/cocoasm/statement.py
@@ -10,7 +10,7 @@ import re
 
 from copy import copy
 
-from cocoasm.exceptions import ParseError, TranslationError, ValueTypeError
+from cocoasm.exceptions import ParseError, TranslationError, ValueTypeError, OperandTypeError
 from cocoasm.instruction import INSTRUCTIONS, CodePackage
 from cocoasm.operands import Operand, OperandType, BadInstructionOperand, ExtendedOperand
 from cocoasm.values import ValueType, NumericValue
@@ -170,6 +170,10 @@ class Statement(object):
         try:
             self.code_pkg = self.operand.translate()
         except ValueError as error:
+            raise TranslationError(str(error), self)
+        except OperandTypeError as error:
+            raise TranslationError(str(error), self)
+        except ValueTypeError as error:
             raise TranslationError(str(error), self)
 
     def check_types(self):

--- a/test/test_program.py
+++ b/test/test_program.py
@@ -121,7 +121,7 @@ class TestProgram(unittest.TestCase):
         self.assertEqual(
             [
                 call("test"),
-                call("line: $                 LABEL   JMP $FFFF                          ; comment                                 ")
+                call("$                 LABEL   JMP $FFFF                          ; comment                                 ")
             ],
             print_mock.mock_calls
         )


### PR DESCRIPTION
This PR updates the error handling routines to properly catch a wide variety of errors thrown during the parsing and translation phases of the assembler. Previously, many `ValueTypeError`, `ParseError` and `TranslationError` would not be caught properly and result in a stack trace. Now, most errors will generate a contextual message, along with the line that the error occurred on. This results in an easier to trace problem, rather than a stack trace that lacks context. 