### PR TITLE
Allow for binary numbers as operands

### DIFF
--- a/cocoasm/values.py
+++ b/cocoasm/values.py
@@ -15,6 +15,11 @@ from cocoasm.exceptions import ValueTypeError
 
 # C O N S T A N T S ###########################################################
 
+# Pattern to recognize a binary value
+BINARY_REGEX = re.compile(
+    r"^%(?P<value>[01]+)$"
+)
+
 # Pattern to recognize a character value
 CHAR_REGEX = re.compile(
     r"^\'(?P<value>[a-zA-Z0-9><'\";:,.#?$%^&*()=!+-/])$"
@@ -240,6 +245,14 @@ class NumericValue(Value):
         data = CHAR_REGEX.match(value)
         if data:
             self.int = ord(data.group("value"))
+            return
+
+        data = BINARY_REGEX.match(value)
+        if data:
+            bit_length = len(data.group("value"))
+            if bit_length != 8 and bit_length != 16:
+                raise ValueTypeError("binary pattern {} must be 8 or 16 bits long".format(data.group("value")))
+            self.int = int(data.group("value"), 2)
             return
 
         data = HEX_REGEX.match(value)

--- a/test/test_program.py
+++ b/test/test_program.py
@@ -137,6 +137,30 @@ class TestProgram(unittest.TestCase):
         )
 
     @patch('builtins.print')
+    def test_binary_string_regression(self, print_mock):
+        statements = [
+            Statement("  NAM LITERAL"),
+            Statement("  ORG $0600"),
+            Statement("START LDA #%10101010"),
+            Statement("  END START"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        program.print_statements()
+        self.assertEqual(
+            [
+                call("-- Assembled Statements --"),
+                call("$0000                         NAM LITERAL                        ;                                         "),
+                call("$0600                         ORG $0600                          ;                                         "),
+                call("$0600 86AA            START   LDA #%10101010                     ;                                         "),
+                call("$0602                         END START                          ;                                         "),
+
+            ],
+            print_mock.mock_calls
+        )
+
+    @patch('builtins.print')
     def test_throw_error_works_correctly(self, print_mock):
         statement = Statement("LABEL JMP $FFFF ; comment")
         program = Program()

--- a/test/test_statement.py
+++ b/test/test_statement.py
@@ -146,6 +146,18 @@ class TestStatement(unittest.TestCase):
         self.assertEqual(0x86, statement1.code_pkg.op_code.int)
         self.assertEqual(62, statement1.code_pkg.additional.int)
 
+    def test_translate_correct_when_8_bit_binary_string_present(self):
+        statement1 = Statement("    LDA #%10101010 ; Load value 170 into register A")
+        statement1.translate()
+        self.assertEqual(0x86, statement1.code_pkg.op_code.int)
+        self.assertEqual(170, statement1.code_pkg.additional.int)
+
+    def test_translate_correct_when_16_bit_binary_string_present(self):
+        statement1 = Statement("    LDD #%1010101010101010 ; Load value 43690 into register D")
+        statement1.translate()
+        self.assertEqual(0xCC, statement1.code_pkg.op_code.int)
+        self.assertEqual(43690, statement1.code_pkg.additional.int)
+
 # M A I N #####################################################################
 
 

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -186,6 +186,19 @@ class TestNumericValue(unittest.TestCase):
             NumericValue("'~")
         self.assertEqual("['~] is not valid integer, character literal, or hex value", str(context.exception))
 
+    def test_numeric_from_binary_string_is_correct(self):
+        result = NumericValue("%10101010")
+        self.assertEqual(170, result.int)
+
+    def test_numeric_from_16_bit_binary_string_is_correct(self):
+        result = NumericValue("%1010101010101010")
+        self.assertEqual(43690, result.int)
+
+    def test_numeric_from_binary_string_throws_exception_when_too_long(self):
+        with self.assertRaises(ValueTypeError) as context:
+            NumericValue("%10101010101010101")
+        self.assertEqual("binary pattern 10101010101010101 must be 8 or 16 bits long", str(context.exception))
+
 
 class TestStringValue(unittest.TestCase):
     """


### PR DESCRIPTION
This PR closes #33 and adds binary number support as operands in the assembler. Binary numbers are recognized by a leading `%` sign, followed by a string of `0` or `1` characters that can be either 8 or 16 bits in length. Unit tests were updated to cover the new functionality. Regression tests added to integration test suite.