### PR TITLE
Add fix for inherent operations with comment that starts with semi-colon

### DIFF
--- a/cocoasm/statement.py
+++ b/cocoasm/statement.py
@@ -25,7 +25,7 @@ COMMENT_LINE_REGEX = re.compile(r"^\s*;\s*(?P<comment>.*)$")
 
 # Pattern to parse a single line
 ASM_LINE_REGEX = re.compile(
-    r"^(?P<label>[\w@]*)\s+(?P<mnemonic>\w*)\s+(?P<operands>[\w\[\]><'\";:,.#?$%^&*()=!+\-/]*)\s*[;]*(?P<comment>.*)$"
+    r"^(?P<label>[\w@]*)\s+(?P<mnemonic>\w*)\s+(?P<operands>[\w\[\]><'\":,.#?$%^&*()=!+\-/]*)\s*[;]*(?P<comment>.*)$"
 )
 
 # Pattern to recognize a direct value

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -131,6 +131,15 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0x30, 0x9D, 0x00, 0x02, 0x96, 0xFF, 0x39], program.get_binary_array())
 
+    def test_assembly_line_regex_with_inherent_operands(self):
+        statements = [
+            Statement("     RTS            ;"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x39], program.get_binary_array())
+
 # M A I N #####################################################################
 
 


### PR DESCRIPTION
This PR fixes a regression that was introduced in a previous pull request. The issue occurs with inherent instructions (i.e. instructions that have no operands). When a comment line is attached to the instruction such as:

```
     RTS    ; return from subroutine
```

the `;` is interpreted as a valid operand character, and is consumed as such. This leads to the incorrect parsing of the entire assembly language statement. This parsing was introduced by issue #39 as part of allowing character literals to appear as operands to various immediate statements. The `;` character was simply removed as a valid character. Regression test added to prevent future parsing problems.

This PR closes #46 