### PR TITLE
Fix regression to allow at symbols in operands

### DIFF
--- a/cocoasm/statement.py
+++ b/cocoasm/statement.py
@@ -25,7 +25,7 @@ COMMENT_LINE_REGEX = re.compile(r"^\s*;\s*(?P<comment>.*)$")
 
 # Pattern to parse a single line
 ASM_LINE_REGEX = re.compile(
-    r"^(?P<label>[\w@]*)\s+(?P<mnemonic>\w*)\s+(?P<operands>[\w\[\]><'\":,.#?$%^&*()=!+\-/]*)\s*[;]*(?P<comment>.*)$"
+    r"^(?P<label>[\w@]*)\s+(?P<mnemonic>\w*)\s+(?P<operands>[\w\[\]><'\"@:,.#?$%^&*()=!+\-/]*)\s*[;]*(?P<comment>.*)$"
 )
 
 # Pattern to recognize a direct value

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -140,6 +140,19 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0x39], program.get_binary_array())
 
+    def test_assembly_line_regex_with_at_symbols_in_operands_and_labels(self):
+        statements = [
+            Statement("         ORG $0100           ;"),
+            Statement("START    LDA #$01            ;"),
+            Statement("         LDA X@              ;"),
+            Statement("X@       FCB 0               ;"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x86, 0x01, 0xB6, 0x01, 0x05, 0x00], program.get_binary_array())
+
+
 # M A I N #####################################################################
 
 


### PR DESCRIPTION
This PR fixes a regression introduced in a prior PR. The `@` symbol should be allowed in operand values. A previous PR took out parsing of `@` symbols in operand values, leading to issues when code such as the following was defined:

```
        LDA G@
G@      FCB 20
```

Fix was implemented, and a regression test was added to catch the issue in the future.