### PR TITLE
Fix ability to explicitly force direct or extended addressing

### DIFF
--- a/cocoasm/operand_type.py
+++ b/cocoasm/operand_type.py
@@ -21,10 +21,12 @@ class OperandType(Enum):
     INDEXED = 3
     EXTENDED_INDIRECT = 4
     EXTENDED = 5
-    DIRECT = 6
-    RELATIVE = 7
-    SYMBOL = 8
-    PSEUDO = 9
-    SPECIAL = 10
+    EXPLICIT_EXTENDED = 6
+    DIRECT = 7
+    EXPLICIT_DIRECT = 8
+    RELATIVE = 9
+    SYMBOL = 10
+    PSEUDO = 11
+    SPECIAL = 12
 
 # E N D   O F   F I L E #######################################################

--- a/cocoasm/values.py
+++ b/cocoasm/values.py
@@ -153,6 +153,8 @@ class Value(ABC):
         try:
             if instruction and instruction.is_16_bit and operand_type == OperandType.IMMEDIATE:
                 return NumericValue(value, size_hint=4)
+            if operand_type == OperandType.EXPLICIT_EXTENDED:
+                return NumericValue(value, size_hint=4)
             return NumericValue(value)
         except ValueTypeError:
             pass

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -152,6 +152,25 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0x86, 0x01, 0xB6, 0x01, 0x05, 0x00], program.get_binary_array())
 
+    def test_explicit_direct_addressing_operand(self):
+        statements = [
+            Statement("         ORG $0100           ;"),
+            Statement("START    LDA <$01            ;"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x96, 0x01], program.get_binary_array())
+
+    def test_explicit_extended_addressing_operand(self):
+        statements = [
+            Statement("         ORG $0100           ;"),
+            Statement("START    LDA >$0001            ;"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xB6, 0x00, 0x01], program.get_binary_array())
 
 # M A I N #####################################################################
 


### PR DESCRIPTION
This PR fixes an issue with the assembler deferring direct or extended mode addressing operands until later on in the assembly process. In instances where the addressing mode was stated explicitly with `<` or `>`, the assembler would fail to recognize the operand type, which would result in the line being skipped during the assembly process. Two new operand types are introduced: `ExplicitDirectOperand` and `ExplicitExtendedOperand`. These two types of operands specifically check to see if the operand uses a `<` or `>` to indicate direct or extended addressing modes respectively. Unit tests added to cover the new functionality. Regression tests added. This PR closes #49 