### PR TITLE
Allow for negative integers in indexed expressions

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -523,6 +523,225 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0x9E, 0x88], program.get_binary_array())
 
+    def test_negative_one_offset_in_indexed_mode(self):
+        statements = [
+            Statement("      STD -1,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x1F], program.get_binary_array())
+
+    def test_negative_5_bit_offset_max_in_indexed_mode(self):
+        statements = [
+            Statement("      STD -16,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x10], program.get_binary_array())
+
+    def test_positive_5_bit_offset_max_in_indexed_mode(self):
+        statements = [
+            Statement("      STD 15,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x0F], program.get_binary_array())
+
+    def test_negative_8_bit_offset_in_indexed_mode(self):
+        statements = [
+            Statement("      STD -17,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x88, 0xEF], program.get_binary_array())
+
+    def test_positive_8_bit_offset_in_indexed_mode(self):
+        statements = [
+            Statement("      STD 17,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x88, 0x11], program.get_binary_array())
+
+    def test_negative_8_bit_offset_max_in_indexed_mode(self):
+        statements = [
+            Statement("      STD -128,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x88, 0x80], program.get_binary_array())
+
+    def test_positive_8_bit_offset_max_in_indexed_mode(self):
+        statements = [
+            Statement("      STD 127,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x88, 0x7F], program.get_binary_array())
+
+    def test_negative_16_bit_offset_in_indexed_mode(self):
+        statements = [
+            Statement("      STD -130,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x89, 0xFF, 0x7E], program.get_binary_array())
+
+    def test_positive_16_bit_offset_in_indexed_mode(self):
+        statements = [
+            Statement("      STD 130,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x89, 0x00, 0x82], program.get_binary_array())
+
+    def test_negative_16_bit_offset_max_in_indexed_mode(self):
+        statements = [
+            Statement("      STD -32768,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x89, 0x80, 0x00], program.get_binary_array())
+
+    def test_positive_16_bit_offset_max_in_indexed_mode(self):
+        statements = [
+            Statement("      STD 32767,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x89, 0x7F, 0xFF], program.get_binary_array())
+
+    def test_zero_offset_in_indexed_mode(self):
+        statements = [
+            Statement("      STD 0,X")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x84], program.get_binary_array())
+
+    def test_zero_offset_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [0,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x94], program.get_binary_array())
+
+    def test_negative_one_offset_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [-1,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        # Should default to 8-bit handling
+        self.assertEqual([0xED, 0x98, 0xFF], program.get_binary_array())
+
+    def test_negative_4_bit_offset_max_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [-16,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        # Should default to 8-bit handling
+        self.assertEqual([0xED, 0x98, 0xF0], program.get_binary_array())
+
+    def test_positive_4_bit_offset_max_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [15,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        # Should default to 8-bit handling
+        self.assertEqual([0xED, 0x98, 0x0F], program.get_binary_array())
+
+    def test_negative_8_bit_offset_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [-17,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x98, 0xEF], program.get_binary_array())
+
+    def test_positive_8_bit_offset_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [17,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x98, 0x11], program.get_binary_array())
+
+    def test_negative_8_bit_offset_max_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [-128,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x98, 0x80], program.get_binary_array())
+
+    def test_positive_8_bit_offset_max_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [127,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x98, 0x7F], program.get_binary_array())
+
+    def test_negative_16_bit_offset_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [-130,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x99, 0xFF, 0x7E], program.get_binary_array())
+
+    def test_positive_16_bit_offset_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [130,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x99, 0x00, 0x82], program.get_binary_array())
+
+    def test_negative_16_bit_offset_max_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [-32768,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x99, 0x80, 0x00], program.get_binary_array())
+
+    def test_positive_16_bit_offset_max_in_extended_indexed_mode(self):
+        statements = [
+            Statement("      STD [32767,X]")
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xED, 0x99, 0x7F, 0xFF], program.get_binary_array())
+
 # M A I N #####################################################################
 
 

--- a/test/test_operands.py
+++ b/test/test_operands.py
@@ -728,19 +728,19 @@ class TestIndexedOperand(unittest.TestCase):
             operand.translate()
         self.assertEqual("[$1F,X+] invalid indexed expression", str(context.exception))
 
-    def test_indexed_5_bit_value_correct(self):
-        operand = IndexedOperand("$1F,X", self.instruction)
+    def test_indexed_4_bit_value_correct(self):
+        operand = IndexedOperand("$F,X", self.instruction)
         operand = operand.resolve_symbols({})
         code_pkg = operand.translate()
         self.assertEqual("AF", code_pkg.op_code.hex())
-        self.assertEqual("1F", code_pkg.post_byte.hex())
+        self.assertEqual("0F", code_pkg.post_byte.hex())
         self.assertEqual(2, code_pkg.size)
 
-        operand = IndexedOperand("$1F,Y", self.instruction)
+        operand = IndexedOperand("$F,Y", self.instruction)
         operand = operand.resolve_symbols({})
         code_pkg = operand.translate()
         self.assertEqual("AF", code_pkg.op_code.hex())
-        self.assertEqual("3F", code_pkg.post_byte.hex())
+        self.assertEqual("2F", code_pkg.post_byte.hex())
         self.assertEqual(2, code_pkg.size)
 
     def test_indexed_8_bit_value_correct(self):
@@ -810,19 +810,19 @@ class TestIndexedOperand(unittest.TestCase):
         self.assertEqual(2, code_pkg.size)
 
     def test_indexed_resolve_left_side_not_symbol_correct(self):
-        operand = IndexedOperand("$1F,X", self.instruction)
+        operand = IndexedOperand("$F,X", self.instruction)
         operand = operand.resolve_symbols({})
         code_pkg = operand.translate()
         self.assertEqual("AF", code_pkg.op_code.hex())
-        self.assertEqual("1F", code_pkg.post_byte.hex())
+        self.assertEqual("0F", code_pkg.post_byte.hex())
         self.assertEqual(2, code_pkg.size)
 
     def test_indexed_resolve_left_side_symbol_correct(self):
-        symbol_table = {'blah': NumericValue("$1F")}
+        symbol_table = {'blah': NumericValue("$F")}
         operand = IndexedOperand("blah,X", self.instruction)
         operand = operand.resolve_symbols(symbol_table)
         code_pkg = operand.translate()
-        self.assertEqual("1F", code_pkg.post_byte.hex())
+        self.assertEqual("0F", code_pkg.post_byte.hex())
 
     def test_indexed_translate_left_address_requires_additional_resolution(self):
         operand = IndexedOperand("$1F,X", self.instruction)

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -221,6 +221,19 @@ class TestNumericValue(unittest.TestCase):
             NumericValue("%10101010101010101")
         self.assertEqual("binary pattern 10101010101010101 must be 8 or 16 bits long", str(context.exception))
 
+    def test_numeric_is_4_bit_zero_value(self):
+        result = NumericValue("0")
+        self.assertTrue(result.is_4_bit())
+
+    def test_numeric_is_4_bit_max_positive(self):
+        result = NumericValue("15")
+        self.assertEqual(15, result.int)
+        self.assertTrue(result.is_4_bit())
+
+    def test_numeric_is_4_bit_max_negative(self):
+        result = NumericValue("-16")
+        self.assertTrue(result.is_4_bit())
+
 
 class TestStringValue(unittest.TestCase):
     """
@@ -459,6 +472,27 @@ class TestExpressionValue(unittest.TestCase):
             result.resolve({})
         self.assertEqual("[VAR+1] unresolved expression", str(context.exception))
 
+    def test_is_8_bit_correct(self):
+        result = NumericValue("127")
+        self.assertTrue(result.is_8_bit())
+        self.assertFalse(result.is_16_bit())
+
+    def test_is_16_bit_correct(self):
+        result = NumericValue("256")
+        self.assertFalse(result.is_8_bit())
+        self.assertTrue(result.is_16_bit())
+
+    def test_negative_value_is_negative(self):
+        result = NumericValue("-1")
+        self.assertTrue(result.is_negative())
+
+    def test_negative_value_get_negative_correct_8_bit(self):
+        result = NumericValue("-1")
+        self.assertEqual(0x81, result.get_negative())
+
+    def test_negative_value_get_negative_correct_16_bit(self):
+        result = NumericValue("-256")
+        self.assertEqual(0x8100, result.get_negative())
 
 # M A I N #####################################################################
 


### PR DESCRIPTION
This PR corrects a number of issues that arise with indexed expressions. As mentioned in issue #36 negative values were not allowed to appear in the left hand side of an indexed expression. This PR allows 4, 8, and 16-bit negative integers to be expressed in the left hand side of an expression. Additionally, this PR fixes issues surrounding the handling of 4-bit integers (specifically, no additional byte is needed past the single post-byte, since the 4-bit offset is encoded directly in the post-byte). This PR also fixes handling of indirect indexed expressions in that any 4-bit offsets now default to 8-bit handling, meaning that a post-byte plus an additional offset byte are added. All of these changes are exercised within unit and integration tests. This PR closes #36 