### PR TITLE
Fix for negative immediate values

### DIFF
--- a/cocoasm/values.py
+++ b/cocoasm/values.py
@@ -375,6 +375,9 @@ class NumericValue(Value):
             self.int = value
             if self.int > 65535:
                 raise ValueTypeError("integer value cannot exceed 65535")
+            if self.int < 0:
+                self.negative = True
+                self.int *= -1
             self.post_init_direct_check()
             return
 
@@ -424,6 +427,7 @@ class NumericValue(Value):
             if self.int > 32768:
                 raise ValueTypeError("integer value cannot be below -32768")
             self.negative = True
+            self.post_init_direct_check()
             return
 
         raise ValueTypeError("[{}] is not valid integer, character literal, or hex value".format(value))
@@ -432,7 +436,7 @@ class NumericValue(Value):
         if not self.negative:
             return self.int
 
-        return self.int | 0x80 if self.int < 128 else self.int | 0x8000
+        return 0x100 - self.int if self.int < 256 else 0x10001 - self.int
 
     def hex(self, size=0):
         if self.size_hint and size == 0:
@@ -441,7 +445,7 @@ class NumericValue(Value):
             size = self.hex_len()
             size += 1 if size % 2 == 1 else 0
         format_specifier = "{{:0>{}X}}".format(size)
-        return format_specifier.format(self.int)
+        return format_specifier.format(self.get_negative())
 
     def hex_len(self):
         if self.size_hint is not None:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -760,6 +760,24 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0xA6, 0x95], program.get_binary_array())
 
+    def test_negative_immediate_8_bit(self):
+        statements = [
+            Statement("         CMPB #-2"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xC1, 0xFE], program.get_binary_array())
+
+    def test_negative_immediate_16_bit(self):
+        statements = [
+            Statement("         CMPX #-258"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x8C, 0xFE, 0xFF], program.get_binary_array())
+
 # M A I N #####################################################################
 
 

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -482,17 +482,33 @@ class TestExpressionValue(unittest.TestCase):
         self.assertFalse(result.is_8_bit())
         self.assertTrue(result.is_16_bit())
 
-    def test_negative_value_is_negative(self):
+    def test_negative_string_value_is_negative(self):
         result = NumericValue("-1")
+        self.assertTrue(result.is_negative())
+
+    def test_negative_int_value_is_negative(self):
+        result = NumericValue(-1)
         self.assertTrue(result.is_negative())
 
     def test_negative_value_get_negative_correct_8_bit(self):
         result = NumericValue("-1")
-        self.assertEqual(0x81, result.get_negative())
+        self.assertEqual(0xFF, result.get_negative())
 
-    def test_negative_value_get_negative_correct_16_bit(self):
-        result = NumericValue("-256")
-        self.assertEqual(0x8100, result.get_negative())
+    def test_negative_string_value_get_negative_correct_8_bit(self):
+        result = NumericValue("-1")
+        self.assertEqual(0xFF, result.get_negative())
+
+    def test_negative_int_value_get_negative_correct_8_bit(self):
+        result = NumericValue(-1)
+        self.assertEqual(0xFF, result.get_negative())
+
+    def test_negative_string_value_get_negative_correct_16_bit(self):
+        result = NumericValue("-258")
+        self.assertEqual(0xFEFF, result.get_negative())
+
+    def test_negative_int_value_get_negative_correct_16_bit(self):
+        result = NumericValue(-258)
+        self.assertEqual(0xFEFF, result.get_negative())
 
 # M A I N #####################################################################
 


### PR DESCRIPTION
This PR closes issue #60 . Specifically, it fixes an issue whereby negative numbers were translated into their absolute value, resulting in positive value outputs instead of negative ones. Unit tests added to cover condition.