### PR TITLE
Simplify handling of indexed PCR statements with expressions

### DIFF
--- a/cocoasm/operands.py
+++ b/cocoasm/operands.py
@@ -123,10 +123,7 @@ class Operand(ABC):
         return self.type == OperandType.DIRECT
 
     def is_indexed(self):
-        return self.type == OperandType.INDEXED
-
-    def is_extended_indexed(self):
-        return self.type == OperandType.EXTENDED_INDIRECT
+        return self.type == OperandType.INDEXED or self.type == OperandType.EXTENDED_INDIRECT
 
     def resolve_symbols(self, symbol_table):
         """

--- a/cocoasm/values.py
+++ b/cocoasm/values.py
@@ -427,7 +427,7 @@ class NumericValue(Value):
             if self.int > 32768:
                 raise ValueTypeError("integer value cannot be below -32768")
             self.negative = True
-            self.post_init_direct_check()
+            # self.post_init_direct_check()
             return
 
         raise ValueTypeError("[{}] is not valid integer, character literal, or hex value".format(value))
@@ -436,7 +436,7 @@ class NumericValue(Value):
         if not self.negative:
             return self.int
 
-        return 0x100 - self.int if self.int < 256 else 0x10001 - self.int
+        return 0x100 - self.int if self.int <= 128 else 0x10000 - self.int
 
     def hex(self, size=0):
         if self.size_hint and size == 0:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -484,7 +484,7 @@ class TestIntegration(unittest.TestCase):
         program = Program()
         program.statements = statements
         program.translate_statements()
-        self.assertEqual([0xAF, 0x8C, 0x04, 0x12], program.get_binary_array())
+        self.assertEqual([0xAF, 0x8C, 0x01, 0x12], program.get_binary_array())
 
     def test_extended_indexed_expression_with_address_resolves_correct(self):
         statements = [
@@ -494,7 +494,7 @@ class TestIntegration(unittest.TestCase):
         program = Program()
         program.statements = statements
         program.translate_statements()
-        self.assertEqual([0xAF, 0x9C, 0x04, 0x12], program.get_binary_array())
+        self.assertEqual([0xAF, 0x9C, 0x01, 0x12], program.get_binary_array())
 
     def test_indexed_with_empty_lhs(self):
         statements = [
@@ -776,7 +776,7 @@ class TestIntegration(unittest.TestCase):
         program = Program()
         program.statements = statements
         program.translate_statements()
-        self.assertEqual([0x8C, 0xFE, 0xFF], program.get_binary_array())
+        self.assertEqual([0x8C, 0xFE, 0xFE], program.get_binary_array())
 
 # M A I N #####################################################################
 

--- a/test/test_operands.py
+++ b/test/test_operands.py
@@ -47,7 +47,7 @@ class TestBaseOperand(unittest.TestCase):
     def test_base_operand_create_from_str_returns_extended_indexed(self):
         instruction = Instruction(mnemonic="ROL", mode=Mode(ind=0x69, ind_sz=2))
         operand = Operand.create_from_str("[$2000]", instruction)
-        self.assertTrue(operand.is_extended_indexed())
+        self.assertTrue(operand.is_indexed())
 
     def test_base_operand_create_from_str_returns_indexed(self):
         instruction = Instruction(mnemonic="ROL", mode=Mode(ind=0x69, ind_sz=2))
@@ -843,7 +843,7 @@ class TestExtendedIndexedOperand(unittest.TestCase):
 
     def test_extended_indexed_type_correct(self):
         result = ExtendedIndexedOperand("[,X]", self.instruction)
-        self.assertTrue(result.is_extended_indexed())
+        self.assertTrue(result.is_indexed())
 
     def test_extended_indexed_string_correct(self):
         result = ExtendedIndexedOperand("[,X]", self.instruction)

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -504,11 +504,11 @@ class TestExpressionValue(unittest.TestCase):
 
     def test_negative_string_value_get_negative_correct_16_bit(self):
         result = NumericValue("-258")
-        self.assertEqual(0xFEFF, result.get_negative())
+        self.assertEqual(0xFEFE, result.get_negative())
 
     def test_negative_int_value_get_negative_correct_16_bit(self):
         result = NumericValue(-258)
-        self.assertEqual(0xFEFF, result.get_negative())
+        self.assertEqual(0xFEFE, result.get_negative())
 
 # M A I N #####################################################################
 


### PR DESCRIPTION
This PR simplifies the handling of indexed statements that contain expressions in them. Originally, the code path created a mess of `if` statements to tackle whether an indexed expression occurred, and also had an expression on the left hand side. The result was an inconsistency into how those statements were handled as opposed to statements that had only a symbol in the left hand side. For example:

    STX ADDR,PCR

is handled with different logic than:

    STX ADDR+1,PCR

This created a bit of a debugging problem when it came time to reconcile the two code paths. This PR simplifies the handling of such statements by adding a single conditional statement. Additionally, the handling of negative values was pushed entirely to the `NumericValue` class, so that awkward statements such as `jump_distance = 0x100 - jump amount` to handle negative numbers didn't get scattered throughout the code base. A few unit tests were updated to catch these new conditions.
