### PR TITLE
Add ability to assemble and save or append to disk image

### DIFF
--- a/assembler.py
+++ b/assembler.py
@@ -14,6 +14,7 @@ from cocoasm.program import Program
 from cocoasm.virtualfiles.virtual_file import VirtualFileType, VirtualFile
 from cocoasm.virtualfiles.source_file import SourceFile, SourceFileType
 from cocoasm.virtualfiles.coco_file import CoCoFile
+from cocoasm.values import NumericValue
 
 # F U N C T I O N S ###########################################################
 
@@ -90,7 +91,10 @@ def main(args):
         name=program.name or args.name,
         load_addr=program.origin,
         exec_addr=program.origin,
-        data=program.get_binary_array()
+        data=program.get_binary_array(),
+        extension="bin",
+        type=NumericValue(0x02),
+        data_type=NumericValue(0x00),
     )
 
     if args.symbols:
@@ -130,6 +134,22 @@ def main(args):
             virtual_file.save_virtual_file(append_mode=args.append)
         except Exception as error:
             print("Unable to save cassette file:")
+            print(error)
+
+    if args.dsk_file:
+        if not coco_file.name:
+            print("No name for the program specified, not creating disk file")
+            return
+        try:
+            virtual_file = VirtualFile(
+                SourceFile(args.dsk_file, file_type=SourceFileType.BINARY),
+                VirtualFileType.DISK
+            )
+            virtual_file.open_virtual_file()
+            virtual_file.add_coco_file(coco_file)
+            virtual_file.save_virtual_file(append_mode=args.append)
+        except Exception as error:
+            print("Unable to save disk file:")
             print(error)
 
 # M A I N #####################################################################

--- a/cocoasm/virtualfiles/virtual_file.py
+++ b/cocoasm/virtualfiles/virtual_file.py
@@ -99,6 +99,18 @@ class VirtualFile(object):
             self.source_file.set_buffer(binary_file.get_buffer())
             self.source_file.write_file()
 
+        if self.virtual_file_type == VirtualFileType.DISK:
+            disk_file = DiskFile()
+            disk_file.add_files(self.coco_file_list)
+            if self.file_exists and not append_mode:
+                raise FileExistsError(
+                    "Target file [{}] already exists, use --append to overwrite".format(
+                        self.source_file.get_file_name()
+                    )
+                )
+            self.source_file.set_buffer(disk_file.get_buffer())
+            self.source_file.write_file()
+
     def add_coco_file(self, coco_file):
         """
         Adds the specified CoCoFile to the virtual image.

--- a/test/virtualfiles/test_disk.py
+++ b/test/virtualfiles/test_disk.py
@@ -8,8 +8,10 @@ A Color Computer Assembler - see the README.md file for details.
 
 import unittest
 
+from mock import patch
+
 from cocoasm.values import NumericValue
-from cocoasm.virtualfiles.disk import DiskFile
+from cocoasm.virtualfiles.disk import DiskFile, DiskConstants, Preamble, Postamble
 from cocoasm.virtualfiles.coco_file import CoCoFile
 from cocoasm.virtualfiles.virtual_file_exceptions import VirtualFileValidationError
 
@@ -26,7 +28,7 @@ class TestDiskFile(unittest.TestCase):
         """
 
     def test_read_sequence_buffer_empty_raises(self):
-        disk_file = DiskFile()
+        disk_file = DiskFile(buffer=[])
         with self.assertRaises(VirtualFileValidationError):
             disk_file.read_sequence(0, 4)
 
@@ -55,7 +57,7 @@ class TestDiskFile(unittest.TestCase):
             disk_file.read_word(0)
 
     def test_validate_sequence_buffer_empty_raises(self):
-        disk_file = DiskFile()
+        disk_file = DiskFile(buffer=[])
         with self.assertRaises(VirtualFileValidationError):
             disk_file.validate_sequence(0, [0xDE, 0xAD, 0xBE, 0xEF])
 
@@ -121,7 +123,7 @@ class TestDiskFile(unittest.TestCase):
         self.assertEqual("DEAD", postamble.exec_addr.hex())
 
     def test_read_data_raises_on_empty_buffer(self):
-        disk_file = DiskFile()
+        disk_file = DiskFile(buffer=[])
         with self.assertRaises(VirtualFileValidationError):
             disk_file.read_data(0, [], data_length=4)
 
@@ -139,6 +141,339 @@ class TestDiskFile(unittest.TestCase):
         self.assertEqual([0x01], data)
         self.assertEqual(6, pointer)
 
+    def test_directory_entry_in_use_raises_on_negative_entry(self):
+        disk_file = DiskFile()
+        with self.assertRaises(VirtualFileValidationError):
+            disk_file.directory_entry_in_use(-1)
+
+    def test_directory_entry_in_use_raises_on_value_too_high(self):
+        disk_file = DiskFile()
+        with self.assertRaises(VirtualFileValidationError):
+            disk_file.directory_entry_in_use(73)
+
+    def test_directory_entry_in_use_correct_when_not_in_use(self):
+        disk_file = DiskFile(buffer=[0x00] * 161280)
+        for entry in range(0, 72):
+            self.assertFalse(disk_file.directory_entry_in_use(entry))
+
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        for entry in range(0, 72):
+            self.assertFalse(disk_file.directory_entry_in_use(entry))
+
+    def test_directory_entry_in_use_correct_when_in_use(self):
+        disk_file = DiskFile(buffer=[0xDE] * 161280)
+        for entry in range(0, 72):
+            self.assertTrue(disk_file.directory_entry_in_use(entry))
+
+    def test_find_empty_directory_entry_returns_negative_when_all_in_use(self):
+        disk_file = DiskFile(buffer=[0xDE] * 161280)
+        self.assertEqual(-1, disk_file.find_empty_directory_entry())
+
+    def test_find_empty_directory_entry_returns_correct_when_none_in_use(self):
+        disk_file = DiskFile(buffer=[0x00] * 161280)
+        self.assertEqual(0, disk_file.find_empty_directory_entry())
+
+    def test_granule_in_use_raises_on_negative_granule(self):
+        disk_file = DiskFile(buffer=[0xDE] * 161280)
+        with self.assertRaises(VirtualFileValidationError):
+            disk_file.granule_in_use(-1)
+
+    def test_granule_in_use_raises_on_granule_too_large(self):
+        disk_file = DiskFile(buffer=[0xDE] * 161280)
+        with self.assertRaises(VirtualFileValidationError):
+            disk_file.granule_in_use(68)
+
+    def test_granule_in_use_correct_when_not_in_use(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        for granule in range(0, 67):
+            self.assertFalse(disk_file.granule_in_use(granule))
+
+    def test_granule_in_use_correct_when_in_use(self):
+        disk_file = DiskFile(buffer=[0xDE] * 161280)
+        for granule in range(0, 67):
+            self.assertTrue(disk_file.granule_in_use(granule))
+
+    def test_granule_in_use_returns_negative_when_no_granules_free(self):
+        disk_file = DiskFile(buffer=[0xDE] * 161280)
+        self.assertEqual(-1, disk_file.find_empty_granule())
+
+    def test_granule_in_use_returns_correct_when_granules_free(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        self.assertEqual(0, disk_file.find_empty_granule())
+
+    def test_granules_needed_empty_file(self):
+        self.assertEqual(1, DiskFile.calculate_granules_needed([]))
+
+    def test_granules_needed_single_byte_file(self):
+        self.assertEqual(1, DiskFile.calculate_granules_needed([]))
+
+    def test_granules_needed_single_granule(self):
+        self.assertEqual(1, DiskFile.calculate_granules_needed([0x00] * (DiskConstants.HALF_TRACK_LEN - 11)))
+
+    def test_granules_needed_two_granules(self):
+        self.assertEqual(2, DiskFile.calculate_granules_needed([0x00] * DiskConstants.HALF_TRACK_LEN))
+
+    def test_sectors_needed_zero_byte_file_correct(self):
+        self.assertEqual(1, DiskFile.calculate_sectors_needed(0))
+
+    def test_sectors_needed_single_sector(self):
+        self.assertEqual(1, DiskFile.calculate_sectors_needed(DiskConstants.BYTES_PER_SECTOR - 11))
+
+    def test_sectors_needed_two_sectors(self):
+        self.assertEqual(2, DiskFile.calculate_sectors_needed(DiskConstants.BYTES_PER_SECTOR))
+
+    def test_calculate_last_sector_bytes_used_zero_length_file_correct(self):
+        self.assertEqual(10, DiskFile.calculate_last_sector_bytes_used([]))
+
+    def test_calculate_last_sector_bytes_used_large_file_correct(self):
+        self.assertEqual(10, DiskFile.calculate_last_sector_bytes_used([0x00] * 2560))
+
+    @patch("cocoasm.virtualfiles.disk.DiskConstants.DIR_OFFSET", 0)
+    def test_write_dir_entry(self):
+        disk_file = DiskFile(buffer=[0x00] * 32)
+        coco_file = CoCoFile(
+            name="test    ",
+            extension="bas",
+            type=NumericValue(0x99),
+            data_type=NumericValue(0x10),
+        )
+        disk_file.write_dir_entry(0, coco_file, 0x20, 0x22)
+        self.assertEqual(
+            [0x54, 0x45, 0x53, 0x54, 0x20, 0x20, 0x20, 0x20, 0x42, 0x41, 0x53, 0x99, 0x10, 0x20, 0x00, 0x22,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            disk_file.get_buffer()
+        )
+
+    @patch("cocoasm.virtualfiles.disk.DiskConstants.DIR_OFFSET", 0)
+    def test_write_dir_entry_space_fills_name(self):
+        disk_file = DiskFile(buffer=[0x00] * 32)
+        coco_file = CoCoFile(
+            name="test",
+            extension="bas",
+            type=NumericValue(0x99),
+            data_type=NumericValue(0x10),
+        )
+        disk_file.write_dir_entry(0, coco_file, 0x20, 0x22)
+        self.assertEqual(
+            [0x54, 0x45, 0x53, 0x54, 0x20, 0x20, 0x20, 0x20, 0x42, 0x41, 0x53, 0x99, 0x10, 0x20, 0x00, 0x22,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            disk_file.get_buffer()
+        )
+
+    def test_calculate_last_granules_sectors_used_empty_file_data(self):
+        self.assertEqual(1, DiskFile.calculate_last_granules_sectors_used([]))
+
+    def test_calculate_last_granules_sectors_used_less_than_one_sector(self):
+        self.assertEqual(1, DiskFile.calculate_last_granules_sectors_used([0x00] * 245))
+
+    def test_calculate_last_granules_sectors_used_more_than_one_sector(self):
+        self.assertEqual(2, DiskFile.calculate_last_granules_sectors_used([0x00] * 500))
+
+    def test_write_preamble_works_correctly(self):
+        preamble = Preamble(
+            load_addr=NumericValue("$DEAD"),
+            data_length=NumericValue("$BEEF"),
+        )
+        disk_file = DiskFile(buffer=[0xAA] * 5)
+        disk_file.write_preamble(preamble, 0)
+        self.assertEqual([0x00, 0xBE, 0xEF, 0xDE, 0xAD], disk_file.get_buffer())
+
+    def test_write_postamble_works_correctly(self):
+        postamble = Postamble(
+            exec_addr=NumericValue("$DEAD")
+        )
+        disk_file = DiskFile(buffer=[0xAA] * 5)
+        disk_file.write_postamble(postamble, 0)
+        self.assertEqual([0xFF, 0x00, 0x00, 0xDE, 0xAD], disk_file.get_buffer())
+
+    def test_write_postamble_does_nothing_if_no_postamble(self):
+        postamble = None
+        disk_file = DiskFile(buffer=[0xAA] * 5)
+        disk_file.write_postamble(postamble, 0)
+        self.assertEqual([0xAA, 0xAA, 0xAA, 0xAA, 0xAA], disk_file.get_buffer())
+
+    def test_write_bytes_to_buffer_empty_bytes_does_nothing(self):
+        disk_file = DiskFile(buffer=[0xAA] * 5)
+        disk_file.write_bytes_to_buffer(0, [])
+        self.assertEqual([0xAA, 0xAA, 0xAA, 0xAA, 0xAA], disk_file.get_buffer())
+
+    def test_write_bytes_works_correctly(self):
+        disk_file = DiskFile(buffer=[0xAA] * 5)
+        disk_file.write_bytes_to_buffer(0, [0xDE, 0xAD, 0xBE, 0xEF])
+        self.assertEqual([0xDE, 0xAD, 0xBE, 0xEF, 0xAA], disk_file.get_buffer())
+
+    @patch("cocoasm.virtualfiles.disk.DiskConstants.FAT_OFFSET", 0)
+    def test_to_fat_no_allocated_granules_does_nothing(self):
+        disk_file = DiskFile(buffer=[0x00] * DiskConstants.TOTAL_GRANULES)
+        disk_file.write_to_fat([], 1)
+        self.assertEqual([0x00] * DiskConstants.TOTAL_GRANULES, disk_file.get_buffer())
+
+    @patch("cocoasm.virtualfiles.disk.DiskConstants.FAT_OFFSET", 0)
+    def test_to_fat_single_granule_correct(self):
+        disk_file = DiskFile(buffer=[0x00] * DiskConstants.TOTAL_GRANULES)
+        disk_file.write_to_fat([2], 1)
+        self.assertEqual(
+            [0x00, 0x00, 0xC1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00
+             ]
+            , disk_file.get_buffer()
+        )
+
+    @patch("cocoasm.virtualfiles.disk.DiskConstants.FAT_OFFSET", 0)
+    def test_to_fat_single_granule_correct(self):
+        disk_file = DiskFile(buffer=[0x00] * DiskConstants.TOTAL_GRANULES)
+        disk_file.write_to_fat([2, 4, 6, 8], 1)
+        self.assertEqual(
+            [0x00, 0x00, 0x04, 0x00, 0x06, 0x00, 0x08, 0x00, 0xC1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00
+             ]
+            , disk_file.get_buffer()
+        )
+
+    def test_list_files_no_entries_returns_empty_list(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        self.assertEqual([], disk_file.list_files())
+
+    def test_list_files_single_entry_correct(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        disk_file.write_bytes_to_buffer(
+            DiskConstants.DIR_OFFSET,
+            [0x54, 0x45, 0x53, 0x54, 0x20, 0x20, 0x20, 0x20, 0x42, 0x49, 0x4E, 0x02, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        )
+        disk_file.write_bytes_to_buffer(
+            0,
+            [0x00, 0x00, 0x01, 0xDE, 0xAD, 0xAA, 0xFF, 0x00, 0x00, 0xBE, 0xEF]
+        )
+        coco_files = disk_file.list_files()
+        self.assertEqual(1, len(coco_files))
+        coco_file = coco_files[0]
+        self.assertEqual("TEST", coco_file.name)
+        self.assertEqual("BIN", coco_file.extension)
+        self.assertEqual(0x02, coco_file.type.int)
+        self.assertEqual(0x00, coco_file.data_type.int)
+        self.assertEqual("DEAD", coco_file.load_addr.hex())
+        self.assertEqual("BEEF", coco_file.exec_addr.hex())
+        self.assertEqual([0xAA], coco_file.data)
+
+    def test_list_files_multiple_entries_correct(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        disk_file.write_bytes_to_buffer(
+            DiskConstants.DIR_OFFSET,
+            [0x54, 0x45, 0x53, 0x54, 0x20, 0x20, 0x20, 0x20, 0x42, 0x49, 0x4E, 0x02, 0x00, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0x53, 0x45, 0x43, 0x4F, 0x4E, 0x44, 0x20, 0x20, 0x42, 0x41, 0x53, 0x00, 0xFF, 0x01, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        )
+        disk_file.write_bytes_to_buffer(
+            DiskFile.seek_granule(0),
+            [0x00, 0x00, 0x01, 0xDE, 0xAD, 0xAA, 0xFF, 0x00, 0x00, 0xBE, 0xEF]
+        )
+        disk_file.write_bytes_to_buffer(
+            DiskFile.seek_granule(1),
+            [0x00, 0x00, 0x02, 0xCA, 0xFE, 0xBB, 0xBB, 0xFF, 0x00, 0x00, 0xBA, 0xBE]
+        )
+        coco_files = disk_file.list_files()
+        self.assertEqual(2, len(coco_files))
+        coco_file = coco_files[0]
+        self.assertEqual("TEST", coco_file.name)
+        self.assertEqual("BIN", coco_file.extension)
+        self.assertEqual(0x02, coco_file.type.int)
+        self.assertEqual(0x00, coco_file.data_type.int)
+        self.assertEqual("DEAD", coco_file.load_addr.hex())
+        self.assertEqual("BEEF", coco_file.exec_addr.hex())
+        self.assertEqual([0xAA], coco_file.data)
+
+        coco_file = coco_files[1]
+        self.assertEqual("SECOND", coco_file.name)
+        self.assertEqual("BAS", coco_file.extension)
+        self.assertEqual(0x00, coco_file.type.int)
+        self.assertEqual(0xFF, coco_file.data_type.int)
+        self.assertEqual("CAFE", coco_file.load_addr.hex())
+        self.assertEqual("BABE", coco_file.exec_addr.hex())
+        self.assertEqual([0xBB, 0xBB], coco_file.data)
+
+    def test_write_to_granules_does_nothing_on_empty_allocated_granules(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        disk_file.write_to_granules([0x00] * 512, [], None, None)
+        self.assertEqual([0xFF] * 161280, disk_file.get_buffer())
+
+    def test_write_to_granules_correct_no_preamble(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        disk_file.write_to_granules([0x00] * 234, [0], None, None)
+        expected = [0x00] * 234
+        expected.extend([0xFF] * 161046)
+        self.assertEqual(expected, disk_file.get_buffer())
+
+    def test_write_to_granules_correct_with_preamble(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        preamble = Preamble(
+            load_addr=NumericValue("$DEAD"),
+            data_length=NumericValue("$BEEF"),
+        )
+        postamble = Postamble(
+            exec_addr=NumericValue("$CAFE")
+        )
+        disk_file.write_to_granules([0x00] * 234, [0], preamble, postamble)
+        expected = [0x00, 0xBE, 0xEF, 0xDE, 0xAD]
+        expected.extend([0x00] * 234)
+        expected.extend([0xFF, 0x00, 0x00, 0xCA, 0xFE])
+        expected.extend([0xFF] * 161036)
+        self.assertEqual(expected, disk_file.get_buffer())
+
+    def test_write_to_granules_multiple_granules_correct(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        disk_file.write_to_granules([0x00] * 2305, [0, 2], None, None)
+        expected = [0xFF] * 161280
+        for pointer in range(0, 2304):
+            expected[pointer] = 0x00
+        expected[4608] = 0x00
+        self.assertEqual(expected, disk_file.get_buffer())
+
+    def test_add_file_raises_if_insufficient_granules_available(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        disk_file.write_bytes_to_buffer(
+            DiskConstants.FAT_OFFSET,
+            [0x00, 0x00, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0,
+             0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0,
+             0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0,
+             0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0, 0xC0]
+        )
+        with self.assertRaises(VirtualFileValidationError):
+            disk_file.add_file(
+                CoCoFile(
+                    name="TEST    ",
+                    extension="BIN",
+                    type=NumericValue(0),
+                    load_addr=NumericValue("$0123"),
+                    exec_addr=NumericValue("$4567"),
+                    data=[0x00] * 5000,
+                )
+            )
+
+    def test_add_file_raises_if_no_directory_entry_available(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280)
+        disk_file.write_bytes_to_buffer(
+            DiskConstants.DIR_OFFSET,
+            [0xAA] * 2304
+        )
+        with self.assertRaises(VirtualFileValidationError):
+            disk_file.add_file(
+                CoCoFile(
+                    name="TEST    ",
+                    extension="BIN",
+                    type=NumericValue(0),
+                    load_addr=NumericValue("$0123"),
+                    exec_addr=NumericValue("$4567"),
+                    data=[0x00] * 5000,
+                )
+            )
 
 # M A I N #####################################################################
 


### PR DESCRIPTION
This PR adds the ability for the assembler to assemble a file and save it to a JV1 style virtual disk using the Disk Extended Color Basic file format. If the disk file does not already exist, it creates a newly formatted virtual disk image, and adds the newly assembled file to the directory structure. If the disk file exists, then it checks to see if the `--append` flag is given on the command line, and then will attempt to update the disk directory entries and file allocation table to hold the newly assembled file. This PR closes #6 and closes #7 . Unit tests were added to cover new functionality. 