### PR TITLE
Implement multi-byte FCB declaractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ as well as the number of cycles used to execute each operation.
 
 | Mnemonic  | Description                                                                | Example               |
 |-----------|----------------------------------------------------------------------------|-----------------------|
-| `FCB`     | Defines a single byte constant value.                                      | `FCB $1C`             |
+| `FCB`     | Defines a byte constant value. Separate multiple bytes with `,`.           | `FCB $1C,$AA`         |
 | `FCC`     | Defines a string constant value enclosed in a matching pair of delimiters. | `FCC "hello"`         |
 | `FDB`     | Defines a two byte constant value.                                         | `FDB $2000`           |
 | `END`     | Defines the end of the program.                                            | `END`                 |

--- a/cocoasm/instruction.py
+++ b/cocoasm/instruction.py
@@ -79,6 +79,7 @@ class Instruction(NamedTuple):
     is_name: bool = False
     is_16_bit: bool = False
     is_lea: bool = False
+    is_multi_byte: bool = False
 
 
 INSTRUCTIONS = [
@@ -234,7 +235,7 @@ INSTRUCTIONS = [
     Instruction(mnemonic="EQU", is_pseudo=True, is_pseudo_define=True),
     Instruction(mnemonic="SET", is_pseudo=True),
     Instruction(mnemonic="RMB", is_pseudo=True),
-    Instruction(mnemonic="FCB", is_pseudo=True),
+    Instruction(mnemonic="FCB", is_pseudo=True, is_multi_byte=True),
     Instruction(mnemonic="FDB", is_pseudo=True),
     Instruction(mnemonic="FCC", is_pseudo=True, is_string_define=True),
     Instruction(mnemonic="SETDP", is_pseudo=True),

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -844,6 +844,16 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0x8C, 0xFE, 0xFE], program.get_binary_array())
 
+    def test_multi_byte_declaration(self):
+        statements = [
+            Statement("         FCB $55,$44,17"),
+            Statement("         FCB $AA"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0x55, 0x44, 0x11, 0xAA], program.get_binary_array())
+
 # M A I N #####################################################################
 
 

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -9,7 +9,8 @@ A Color Computer Assembler - see the README.md file for details.
 import unittest
 
 from cocoasm.values import NumericValue, StringValue, NoneValue, SymbolValue, \
-    AddressValue, Value, ExpressionValue, ExplicitAddressingMode, LeftRightValue
+    AddressValue, Value, ExpressionValue, ExplicitAddressingMode, LeftRightValue, \
+    MultiByteValue
 from cocoasm.instruction import Instruction, Mode
 from cocoasm.exceptions import ValueTypeError
 
@@ -275,6 +276,45 @@ class TestNumericValue(unittest.TestCase):
     def test_numeric_negative_int_value_get_negative_correct_16_bit(self):
         result = NumericValue(-258)
         self.assertEqual(0xFEFE, result.get_negative())
+
+
+class TestMultiByteValue(unittest.TestCase):
+    """
+    A test class for the StringValue class.
+    """
+    def setUp(self):
+        """
+        Common setup routines needed for all unit tests.
+        """
+        pass
+
+    def test_multi_byte_raises_on_no_delimiter(self):
+        with self.assertRaises(ValueTypeError) as context:
+            MultiByteValue('$DE')
+        self.assertEqual("multi-byte declarations must have a comma in them", str(context.exception))
+
+    def test_multi_byte_no_values_correct(self):
+        result = MultiByteValue(",")
+        self.assertEqual("", result.hex())
+        self.assertEqual(0, result.hex_len())
+
+    def test_multi_byte_single_value_correct(self):
+        result = MultiByteValue("$DE,")
+        self.assertEqual("DE", result.hex())
+        self.assertEqual(2, result.hex_len())
+
+    def test_multi_byte_many_values_correct(self):
+        result = MultiByteValue("$DE,$AD,$BE,$EF")
+        self.assertEqual("DEADBEEF", result.hex())
+        self.assertEqual(8, result.hex_len())
+
+    def test_multi_byte_8_bit_correct(self):
+        result = MultiByteValue("$DE,$AD,$BE,$EF")
+        self.assertFalse(result.is_8_bit())
+
+    def test_multi_byte_16_bit_correct(self):
+        result = MultiByteValue("$DE,$AD,$BE,$EF")
+        self.assertFalse(result.is_16_bit())
 
 
 class TestStringValue(unittest.TestCase):


### PR DESCRIPTION
This PR adds the ability to define multiple single byte declarations using a single `FCB` statement. Previously, all `FCB` statements only accepted a single byte definition. For example, to define 3 constant bytes, you would have to:

    FCB $55
    FCB $44
    FCB 17

Now, `FCB` statements allow for multiple declarations per line, separated with a comma. The following would be equivalent to the code above:

    FCB $55,$44,17

Unit and integration tests were added to catch new conditions. `README.md` documentation was updated to reference multi-byte functionality. This PR closes #53 