### PR TITLE
Create new `granule_fill_order` attribute to specify granule allocation preference

### DIFF
--- a/test/virtualfiles/test_disk.py
+++ b/test/virtualfiles/test_disk.py
@@ -193,13 +193,22 @@ class TestDiskFile(unittest.TestCase):
         for granule in range(0, 67):
             self.assertTrue(disk_file.granule_in_use(granule))
 
-    def test_granule_in_use_returns_negative_when_no_granules_free(self):
+    def test_find_empty_granule_returns_negative_when_no_granules_free(self):
         disk_file = DiskFile(buffer=[0xDE] * 161280)
         self.assertEqual(-1, disk_file.find_empty_granule())
 
-    def test_granule_in_use_returns_correct_when_granules_free(self):
+    def test_find_empty_granule_returns_correct_when_granules_free(self):
         disk_file = DiskFile(buffer=[0xFF] * 161280)
+        self.assertEqual(32, disk_file.find_empty_granule())
+
+    def test_find_empty_granule_returns_correct_when_granules_free_with_different_preferred_granules(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280, granule_fill_order=[x for x in range(68)])
         self.assertEqual(0, disk_file.find_empty_granule())
+
+    def test_find_empty_granule_raises_when_fill_order_too_small(self):
+        disk_file = DiskFile(buffer=[0xFF] * 161280, granule_fill_order=[0])
+        with self.assertRaises(VirtualFileValidationError):
+            disk_file.find_empty_granule()
 
     def test_granules_needed_empty_file(self):
         self.assertEqual(1, DiskFile.calculate_granules_needed([]))


### PR DESCRIPTION
This PR updates the `DiskFile` class to have an attribute called `granule_fill_order`. This list-like object is exactly 68 elements long. Each entry in the list specifies the granule number that should be checked to see if it is empty. The order of the list reflects which granules are allocated first. In `DiskConstants` there is a constant called `GRANULE_FILL_ORDER` that mimics the way Disk BASIC attempts to allocate granules on the disk. In general, Disk BASIC attempts to fill granules near the center of the disk first to minimize head stepping. This same ordering is implemented within this PR. The class can be instantiated with a different ordering list, allowing for future customization when generating disk images. Unit tests updated to cover new conditions. This PR closes #73 