### PR TITLE
Fix bug where non-machine language files could not be read

### DIFF
--- a/cocoasm/virtualfiles/coco_file.py
+++ b/cocoasm/virtualfiles/coco_file.py
@@ -54,8 +54,10 @@ class CoCoFile(NamedTuple):
                 gaps = "Gaps"
             result += "Gap Status: {}\n".format(gaps)
 
-        result += "Load Addr:  ${}\n".format(self.load_addr.hex(size=4))
-        result += "Exec Addr:  ${}\n".format(self.exec_addr.hex(size=4))
+        if self.type.hex() == "02":
+            result += "Load Addr:  ${}\n".format(self.load_addr.hex(size=4))
+            result += "Exec Addr:  ${}\n".format(self.exec_addr.hex(size=4))
+
         result += "Data Len:   {} bytes".format(len(self.data))
         return result
 

--- a/test/virtualfiles/test_coco_file.py
+++ b/test/virtualfiles/test_coco_file.py
@@ -30,6 +30,14 @@ class TestCoCoFile(unittest.TestCase):
             'Filename:   {}\nExtension:  {}\nFile Type:  {}\nData Type:  {}\n'
             'Load Addr:  ${}\nExec Addr:  ${}\nData Len:   {} bytes'
         )
+        self.str_format_no_exec = (
+            'Filename:   {}\nExtension:  {}\nFile Type:  {}\nData Type:  {}\nGap Status: {}\n'
+            'Data Len:   {} bytes'
+        )
+        self.str_format_no_gaps_no_exec = (
+            'Filename:   {}\nExtension:  {}\nFile Type:  {}\nData Type:  {}\n'
+            'Data Len:   {} bytes'
+        )
         self.name = "testfile"
         self.extension = "bas"
         self.file_type = NumericValue(0)
@@ -53,24 +61,34 @@ class TestCoCoFile(unittest.TestCase):
             gaps=self.gaps,
         )
 
-    def compose_expected_string(self):
-        return self.str_format.format(
-            self.name, self.extension, self.file_type, self.data_type, self.ignore_gaps,
-            self.load_addr, self.exec_addr, len(self.data)
-        )
-
-    def compose_expected_string_ignore_gaps(self):
-        return self.str_format_no_gaps.format(
-            self.name, self.extension, self.file_type, self.data_type,
-            self.load_addr, self.exec_addr, len(self.data)
-        )
+    def compose_expected_string(self, ignore_gaps=False, is_basic_file=False):
+        if not ignore_gaps and not is_basic_file:
+            return self.str_format.format(
+                self.name, self.extension, self.file_type, self.data_type, self.ignore_gaps,
+                self.load_addr, self.exec_addr, len(self.data)
+            )
+        if ignore_gaps and not is_basic_file:
+            return self.str_format_no_gaps.format(
+                self.name, self.extension, self.file_type, self.data_type,
+                self.load_addr, self.exec_addr, len(self.data)
+            )
+        if not ignore_gaps and is_basic_file:
+            return self.str_format_no_exec.format(
+                self.name, self.extension, self.file_type, self.data_type, self.ignore_gaps,
+                len(self.data)
+            )
+        if ignore_gaps and is_basic_file:
+            return self.str_format_no_gaps_no_exec.format(
+                self.name, self.extension, self.file_type, self.data_type,
+                len(self.data)
+            )
 
     def test_str_is_correct_default_branches(self):
         result = self.compose_coco_file()
         self.ignore_gaps = "No Gaps"
         self.file_type = "BASIC"
         self.data_type = "Binary"
-        self.assertEqual(self.compose_expected_string(), str(result))
+        self.assertEqual(self.compose_expected_string(is_basic_file=True), str(result))
 
     def test_str_is_correct_data_filetype(self):
         self.file_type = NumericValue(1)
@@ -78,7 +96,7 @@ class TestCoCoFile(unittest.TestCase):
         self.ignore_gaps = "No Gaps"
         self.file_type = "Data"
         self.data_type = "Binary"
-        self.assertEqual(self.compose_expected_string(), str(result))
+        self.assertEqual(self.compose_expected_string(is_basic_file=True), str(result))
 
     def test_str_is_correct_object_filetype(self):
         self.file_type = NumericValue(2)
@@ -94,7 +112,7 @@ class TestCoCoFile(unittest.TestCase):
         self.ignore_gaps = "No Gaps"
         self.file_type = "Text"
         self.data_type = "Binary"
-        self.assertEqual(self.compose_expected_string(), str(result))
+        self.assertEqual(self.compose_expected_string(is_basic_file=True), str(result))
 
     def test_str_is_correct_ascii_datatype(self):
         self.data_type = NumericValue(0xFF)
@@ -102,7 +120,7 @@ class TestCoCoFile(unittest.TestCase):
         self.ignore_gaps = "No Gaps"
         self.file_type = "BASIC"
         self.data_type = "ASCII"
-        self.assertEqual(self.compose_expected_string(), str(result))
+        self.assertEqual(self.compose_expected_string(is_basic_file=True), str(result))
 
     def test_str_is_correct_gaps(self):
         self.gaps = NumericValue(0xFF)
@@ -110,14 +128,14 @@ class TestCoCoFile(unittest.TestCase):
         self.ignore_gaps = "Gaps"
         self.file_type = "BASIC"
         self.data_type = "Binary"
-        self.assertEqual(self.compose_expected_string(), str(result))
+        self.assertEqual(self.compose_expected_string(is_basic_file=True), str(result))
 
     def test_str_is_correct_ignore_gaps(self):
         self.ignore_gaps = True
         result = self.compose_coco_file()
         self.file_type = "BASIC"
         self.data_type = "Binary"
-        self.assertEqual(self.compose_expected_string_ignore_gaps(), str(result))
+        self.assertEqual(self.compose_expected_string(ignore_gaps=True, is_basic_file=True), str(result))
 
 
 # M A I N #####################################################################


### PR DESCRIPTION
This PR fixes a problem when attempting to read file information from virtual disk. Any file type that was not marked as machine language could not be read. This was due to the fact that the virtual disk file assumed that every file had preamble and postamble information associated with it. This isn't the case with file types such as ASCII files or BASIC files. A check is now performed on the file type first before preamble or postamble data is read. A new method was introduced to calculate file size due to the fact that file size information was previously only read from the preamble. Unit tests updated to catch new conditions. This PR closes #79 