### PR TITLE
Allow for multi-word declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ as well as the number of cycles used to execute each operation.
 |-----------|----------------------------------------------------------------------------|-----------------------|
 | `FCB`     | Defines a byte constant value. Separate multiple bytes with `,`.           | `FCB $1C,$AA`         |
 | `FCC`     | Defines a string constant value enclosed in a matching pair of delimiters. | `FCC "hello"`         |
-| `FDB`     | Defines a two byte constant value.                                         | `FDB $2000`           |
+| `FDB`     | Defines a word constant value. Separate multiple word with `,`.            | `FDB $2000,$CAFE`     |
 | `END`     | Defines the end of the program.                                            | `END`                 |
 | `EQU`     | Defines a symbol with a set value.                                         | `SCRMEM EQU $1000`    |
 | `INCLUDE` | Includes another assembly source file at this location.                    | `INCLUDE globals.asm` |

--- a/cocoasm/instruction.py
+++ b/cocoasm/instruction.py
@@ -80,6 +80,7 @@ class Instruction(NamedTuple):
     is_16_bit: bool = False
     is_lea: bool = False
     is_multi_byte: bool = False
+    is_multi_word: bool = False
 
 
 INSTRUCTIONS = [
@@ -236,7 +237,7 @@ INSTRUCTIONS = [
     Instruction(mnemonic="SET", is_pseudo=True),
     Instruction(mnemonic="RMB", is_pseudo=True),
     Instruction(mnemonic="FCB", is_pseudo=True, is_multi_byte=True),
-    Instruction(mnemonic="FDB", is_pseudo=True),
+    Instruction(mnemonic="FDB", is_pseudo=True, is_multi_word=True),
     Instruction(mnemonic="FCC", is_pseudo=True, is_string_define=True),
     Instruction(mnemonic="SETDP", is_pseudo=True),
     Instruction(mnemonic="INCLUDE", is_pseudo=True, is_include=True),

--- a/cocoasm/values.py
+++ b/cocoasm/values.py
@@ -79,6 +79,7 @@ class ValueType(Enum):
     LEFT_RIGHT = 7
     ADDRESS_EXPRESSION = 8
     MULTI_BYTE = 9
+    MULTI_WORD = 10
 
 
 class Value(ABC):
@@ -173,6 +174,9 @@ class Value(ABC):
 
     def is_multi_byte(self):
         return self.type == ValueType.MULTI_BYTE
+
+    def is_multi_word(self):
+        return self.type == ValueType.MULTI_WORD
 
     def resolve(self, symbol_table):
         """
@@ -320,6 +324,29 @@ class MultiByteValue(Value):
             raise ValueTypeError("multi-byte declarations must have a comma in them")
         values = value.split(",")
         self.hex_array = [NumericValue(x).hex(size=2) for x in values if x != ""]
+
+    def hex(self, size=0):
+        return "".join(self.hex_array)
+
+    def hex_len(self):
+        return len(self.hex())
+
+    def is_8_bit(self):
+        return False
+
+    def is_16_bit(self):
+        return False
+
+
+class MultiWordValue(Value):
+    def __init__(self, value):
+        super().__init__(value)
+        self.hex_array = []
+        self.type = ValueType.MULTI_WORD
+        if "," not in value:
+            raise ValueTypeError("multi-word declarations must have a comma in them")
+        values = value.split(",")
+        self.hex_array = [NumericValue(x).hex(size=4) for x in values if x != ""]
 
     def hex(self, size=0):
         return "".join(self.hex_array)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -854,6 +854,16 @@ class TestIntegration(unittest.TestCase):
         program.translate_statements()
         self.assertEqual([0x55, 0x44, 0x11, 0xAA], program.get_binary_array())
 
+    def test_multi_word_declaration(self):
+        statements = [
+            Statement("         FDB $DEAD,$BEEF"),
+            Statement("         FDB $CAFE"),
+        ]
+        program = Program()
+        program.statements = statements
+        program.translate_statements()
+        self.assertEqual([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE], program.get_binary_array())
+
 # M A I N #####################################################################
 
 

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -10,7 +10,7 @@ import unittest
 
 from cocoasm.values import NumericValue, StringValue, NoneValue, SymbolValue, \
     AddressValue, Value, ExpressionValue, ExplicitAddressingMode, LeftRightValue, \
-    MultiByteValue
+    MultiByteValue, MultiWordValue
 from cocoasm.instruction import Instruction, Mode
 from cocoasm.exceptions import ValueTypeError
 
@@ -280,7 +280,7 @@ class TestNumericValue(unittest.TestCase):
 
 class TestMultiByteValue(unittest.TestCase):
     """
-    A test class for the StringValue class.
+    A test class for the MultiByteValue class.
     """
     def setUp(self):
         """
@@ -314,6 +314,45 @@ class TestMultiByteValue(unittest.TestCase):
 
     def test_multi_byte_16_bit_correct(self):
         result = MultiByteValue("$DE,$AD,$BE,$EF")
+        self.assertFalse(result.is_16_bit())
+
+
+class TestMultiWordValue(unittest.TestCase):
+    """
+    A test class for the StringValue class.
+    """
+    def setUp(self):
+        """
+        Common setup routines needed for all unit tests.
+        """
+        pass
+
+    def test_multi_word_raises_on_no_delimiter(self):
+        with self.assertRaises(ValueTypeError) as context:
+            MultiWordValue('$DEAD')
+        self.assertEqual("multi-word declarations must have a comma in them", str(context.exception))
+
+    def test_multi_word_no_values_correct(self):
+        result = MultiWordValue(",")
+        self.assertEqual("", result.hex())
+        self.assertEqual(0, result.hex_len())
+
+    def test_multi_word_single_value_correct(self):
+        result = MultiWordValue("$DEAD,")
+        self.assertEqual("DEAD", result.hex())
+        self.assertEqual(4, result.hex_len())
+
+    def test_multi_word_many_values_correct(self):
+        result = MultiWordValue("$DEAD,$BEEF")
+        self.assertEqual("DEADBEEF", result.hex())
+        self.assertEqual(8, result.hex_len())
+
+    def test_multi_byte_8_bit_correct(self):
+        result = MultiWordValue("$DEAD,$BEEF")
+        self.assertFalse(result.is_8_bit())
+
+    def test_multi_byte_16_bit_correct(self):
+        result = MultiWordValue("$DEAD,$BEEF")
         self.assertFalse(result.is_16_bit())
 
 


### PR DESCRIPTION
This PR allows for multi-word `FDB` expressions. For example:

```
    FDB $DEAD,$CAFE
```

Unit tests added to cover new conditions. This PR closes #63 