### PR TITLE
Add line length specifier to assembler

### DIFF
--- a/assembler.py
+++ b/assembler.py
@@ -38,6 +38,10 @@ def parse_arguments():
         help="print out the assembled statements when finished"
     )
     parser.add_argument(
+        "--print_length", metavar="LEN", help="truncates each assembly line printed to LEN characters",
+        default=0, type=int,
+    )
+    parser.add_argument(
         "--to_bin", metavar="BIN_FILE", help="stores the assembled program in a binary BIN_FILE"
     )
     parser.add_argument(
@@ -91,7 +95,7 @@ def main(args):
     program = Program()
 
     try:
-        program.process(source_file.get_buffer())
+        program.process(source_file.get_buffer(), line_length=args.print_length)
     except TranslationError as error:
         throw_error(error)
     except ParseError as error:

--- a/cocoasm/program.py
+++ b/cocoasm/program.py
@@ -30,31 +30,33 @@ class Program(object):
         self.name = None
         self.macros = dict()
 
-    def process(self, source_file):
+    def process(self, source_file, line_length=0):
         """
         Processes a filename for assembly.
 
         :param source_file: the source file to process
+        :param line_length: the maximum length of a statement when printed
         """
-        self.statements = self.parse(source_file)
+        self.statements = self.parse(source_file, line_length=line_length)
         self.translate_statements()
 
     @classmethod
-    def parse(cls, contents):
+    def parse(cls, contents, line_length=0):
         """
         Parses a single file and saves the set of statements.
 
         :param contents: a list of strings, each string represents one line of assembly
+        :param line_length: sets the maximum length of a printed statement
         """
         statements = []
         for line in contents:
-            statement = Statement(line)
+            statement = Statement(line, line_length=line_length)
             if not statement.is_empty and not statement.is_comment_only:
                 statements.append(statement)
         return statements
 
     @classmethod
-    def process_mnemonics(cls, statements):
+    def process_mnemonics(cls, statements, line_length=0):
         """
         Given a list of statements, processes the mnemonics on each statement, and
         assigns each statement an Instruction object. If the statement is the
@@ -63,6 +65,7 @@ class Program(object):
         it will excise the macro code from the list of statements.
 
         :param statements: the list of statements to process
+        :param line_length: sets the maximum length of a printed statement
         :return: a list of processed statements, a list of processed macros
         """
         processed_statements = []
@@ -77,7 +80,12 @@ class Program(object):
             if include_filename:
                 include_source = SourceFile(include_filename)
                 include_source.read_file()
-                include, included_macros = cls.process_mnemonics(cls.parse(include_source.get_buffer()))
+                include, included_macros = cls.process_mnemonics(
+                    cls.parse(
+                        include_source.get_buffer(),
+                        line_length=line_length
+                    )
+                )
                 processed_statements.extend(include)
                 macros.update(included_macros)
             else:
@@ -267,9 +275,6 @@ class Program(object):
         """
         Returns a list of strings. Each string represents one assembled statement
         """
-        lines = []
-        for index, statement in enumerate(self.statements):
-            lines.append(f"{str(statement)}")
-        return lines
+        return [str(statement) for statement in self.statements]
 
 # E N D   O F   F I L E #######################################################

--- a/cocoasm/statement.py
+++ b/cocoasm/statement.py
@@ -56,7 +56,7 @@ class Statement(object):
     The statement can be parsed and translated to its Chip8 machine code
     equivalent.
     """
-    def __init__(self, line):
+    def __init__(self, line, line_length=0):
         self.is_empty = True
         self.is_comment_only = False
         self.macro_name = ""
@@ -73,6 +73,7 @@ class Statement(object):
         self.pcr_size_hint = 2
         self.code_pkg = CodePackage()
         self.original_line = line
+        self.line_length = line_length
         self.compile_macro_call_regex()
         self.parse_line(line)
 
@@ -82,15 +83,16 @@ class Statement(object):
         op_code_string += self.code_pkg.post_byte.hex()
         op_code_string += self.code_pkg.additional.hex()
 
-        return "${} {:.10} {} {} {} ; {}".format(
-            self.code_pkg.address.hex(size=4),
-            op_code_string.ljust(10, ' '),
-            self.label.rjust(10, ' '),
-            self.mnemonic.rjust(5, ' '),
-            self.original_operand.operand_string.ljust(30, ' '),
-            self.comment.ljust(40, ' '),
-            # self.operand.type
-        )
+        address = self.code_pkg.address.hex(size=4)
+        op_string = op_code_string.ljust(10, ' ')
+        label = self.label.rjust(10, ' ')
+        mnemonic = self.mnemonic.rjust(5, ' ')
+        original = self.original_operand.operand_string.ljust(30, ' ')
+        comment = self.comment.ljust(40, ' ')
+
+        result = f"${address} {op_string:.10} {label} {mnemonic} {original} ; {comment}"
+
+        return result if self.line_length <= 0 else result[:self.line_length]
 
     def __eq__(self, other):
         return self.is_empty == other.is_empty and \

--- a/test/test_program.py
+++ b/test/test_program.py
@@ -333,6 +333,27 @@ class TestProgram(unittest.TestCase):
         self.assertEqual(expected, statements)
         self.assertEqual(0x0600, program.exec_address.int)
 
+    def test_line_length_truncates_correctly(self):
+        statements = [
+            "  NAM EXECADDR",
+            "  ORG $0600",
+            "  FCB $01",
+            "START LDA #$00",
+            "  END START",
+        ]
+        program = Program()
+        program.process(statements, line_length=35)
+        statements = program.get_statements()
+        expected = [
+          "$0000                         NAM E",
+          "$0600                         ORG $",
+          "$0600 01                      FCB $",
+          "$0601 8600            START   LDA #",
+          "$0603                         END S",
+        ]
+        self.assertEqual(expected, statements)
+        self.assertEqual(0x0601, program.exec_address.int)
+
     def test_translation_error_raised_on_bad_label(self):
         statement = Statement("LABEL JMP EXIT ; comment")
         program = Program()


### PR DESCRIPTION
This PR adds a line length specifier as an option to the assembler as `--print_length`. This controls how many characters are allowed to be printed to the standard output when asking the assembler to `--print` the output of assembly. Integration test added to catch new conditions. This PR closes #84 