### PR TITLE
Check relative branches for byte overflows

### DIFF
--- a/cocoasm/statement.py
+++ b/cocoasm/statement.py
@@ -326,10 +326,18 @@ class Statement(object):
                 length = 1
                 for statement in statements[branch_index:this_index+1]:
                     length += statement.code_pkg.size
+
+                # Check for overflow errors if this is a short relative operation
+                if self.instruction.is_short_branch and length > 128:
+                    raise TranslationError(f"short relative branch cannot be less than -128 bytes", self)
                 self.code_pkg.additional = NumericValue(base_value - length, size_hint=size_hint)
             else:
                 for statement in statements[this_index+1:branch_index]:
                     length += statement.code_pkg.size
+
+                # Check for overflow errors if this is a short relative operation
+                if self.instruction.is_short_branch and length > 127:
+                    raise TranslationError(f"short relative branch cannot be more than 127 bytes", self)
                 self.code_pkg.additional = NumericValue(length, size_hint=size_hint)
             return
 

--- a/test/test_program.py
+++ b/test/test_program.py
@@ -361,6 +361,36 @@ class TestProgram(unittest.TestCase):
             program.statements = [statement]
             program.translate_statements()
 
+    def test_translation_error_raised_on_short_branch_too_large_backward_branch(self):
+        statements = [
+            "  ORG $0600",
+            "START LDA #$01",
+        ]
+        for x in range(400):
+            statements.append("    LDA #$01")
+        statements.append("  BRA START")
+        program = Program()
+        with self.assertRaises(TranslationError) as context:
+            program.process(statements)
+
+        the_exception = context.exception
+        self.assertEqual("short relative branch cannot be less than -128 bytes", the_exception.value)
+
+    def test_translation_error_raised_on_short_branch_too_large_forward_branch(self):
+        statements = [
+            "  ORG $0600",
+            "START BRA THEEND",
+        ]
+        for x in range(400):
+            statements.append("    LDA #$01")
+        statements.append("THEEND  LDA #$01")
+        program = Program()
+        with self.assertRaises(TranslationError) as context:
+            program.process(statements)
+
+        the_exception = context.exception
+        self.assertEqual("short relative branch cannot be more than 127 bytes", the_exception.value)
+
     def test_get_binary_array_empty_if_no_statements(self):
         program = Program()
         self.assertEqual([], program.get_binary_array())


### PR DESCRIPTION
This PR creates a specific check when relative branching operations are in use. Specifically, if the branch is a short branch operation, it will check for byte overflow errors. If the branch target is more than 127 bytes ahead, or more than -128 bytes behind, then the assembler will throw a translation error. The user will then need to update the assembly program listing to use the long branch instruction variant instead. Unit tests added to catch new functionality. This PR closes #75 